### PR TITLE
Remove Dependabot Branches from Workflow

### DIFF
--- a/.github/workflows/docs-sandbox.yml
+++ b/.github/workflows/docs-sandbox.yml
@@ -3,6 +3,8 @@ name: Deploy Docs to Sandbox
 on:
   pull_request:
     branches: [ main ]
+    branches-ignore:
+      - "dependabot/**"
 
   workflow_dispatch:
 


### PR DESCRIPTION
Dependabot PRs cannot access secrets and we don't necessarily want them overwriting what is in the test environment. This PR will ignore those branches before running the action.