### PR TITLE
Breadcrumb link update

### DIFF
--- a/docs/_includes/breadcrumbs.njk
+++ b/docs/_includes/breadcrumbs.njk
@@ -8,13 +8,17 @@
       </a>
     </li>
     {%- for entry in entries %}
-      {% if entry.url in page.url %}
-        <li class="breadcrumb-item">
-          <a href="{{ entry.url | url }}">
-            {{ entry.title }}
-          </a>
+      {% if entry.url == page.url %}
+        <li class="breadcrumb-item active" aria-current="page">
+          {{ entry.title }}
         </li>
-        {% if entry.children %}
+      {% elif entry.url in page.url %}
+        {% if entry.children.length > 0 %}
+          <li class="breadcrumb-item">
+            <a href="{{ entry.url | url }}">
+              {{ entry.title }}
+            </a>
+          </li>
           {%- for child in entry.children %}
             {% if child.url == page.url %}
               <li class="breadcrumb-item active" aria-current="page">


### PR DESCRIPTION
Made it so that the logic checks the first layer of items for a url match, and if there is, make an addition to the breadcrumb without a font awesome icon; the logic for the submenu items remains the same (similar to in the sidebar.njk file) with the parent navigation link being created beforehand.