### PR TITLE
Remove Dependabot check from Sandbox Deployment

### DIFF
--- a/.github/workflows/docs-sandbox.yml
+++ b/.github/workflows/docs-sandbox.yml
@@ -3,8 +3,6 @@ name: Deploy Docs to Sandbox
 on:
   pull_request:
     branches: [ main ]
-    branches-ignore:
-      - "dependabot/**"
 
   workflow_dispatch:
 


### PR DESCRIPTION
Removing this change. Actions does not allow both `branches` and `branches-ignore` to be defined at the same time.