### PR TITLE
Breadcrumb touchup

### DIFF
--- a/docs/_includes/breadcrumbs.njk
+++ b/docs/_includes/breadcrumbs.njk
@@ -1,5 +1,5 @@
 {% set entries = collections.all | eleventyNavigation %}
-<nav aria-label="breadcrumb">
+<nav class="breadcrumb-wrapper" aria-label="breadcrumb">
   <ol class="breadcrumb">
     <li class="breadcrumb-item">
       <a href="{{ '/' | url }}">

--- a/docs/_includes/markup/breadcrumbs.njk
+++ b/docs/_includes/markup/breadcrumbs.njk
@@ -1,4 +1,4 @@
-<nav aria-label="breadcrumbs" class="breadcrumb-wrapper">
+<nav class="breadcrumb-wrapper" aria-label="breadcrumbs" class="breadcrumb-wrapper">
   <ol class="breadcrumb">
     <li class="breadcrumb-item">
       <a href="/">


### PR DESCRIPTION
This PR restores the border under the breadcrumbs.

Before
<img width="366" alt="01" src="https://user-images.githubusercontent.com/10730801/153892032-d62a988e-dbda-4922-8b48-6da9eeead6ad.png">

After
<img width="366" alt="02" src="https://user-images.githubusercontent.com/10730801/153892091-f2200f18-1d4e-401e-9db5-cb8a2c5723f7.png">

