### PR TITLE
Typography - page revision

### DIFF
--- a/docs/foundation/typography.md
+++ b/docs/foundation/typography.md
@@ -82,6 +82,7 @@ Span tags `<span>` allow local text changes without affecting semantics. We can 
 
 ```html
 Span tags `<span>` allow local text changes without affecting semantics. We can style <span class="text-danger">words in this sentence to be red</span> without affecting the semantics. This text can be <span class="fw-bold">bolder</span> without affecting the semantics. This text can be <span class="fst-italic">italicized</span> without affecting the semantics. 
+```
 
 ## Resources
 


### PR DESCRIPTION
The Foundation > Typography page has a missing section header, Resources, that is inside of the last HTML rendering.
This has been separated in the md file as other pages have it.