### PR TITLE
Remove dependabot from sandbox deployments

### DIFF
--- a/.github/workflows/docs-sandbox.yml
+++ b/.github/workflows/docs-sandbox.yml
@@ -2,7 +2,8 @@ name: Deploy Docs to Sandbox
 
 on:
   pull_request:
-    branches: [ main ]
+    branches-ignore:
+      - "dependabot/**"
 
   workflow_dispatch:
 


### PR DESCRIPTION
Attempting to remove the dependabot PRs from being deployed to Sandbox whenever they are opened. This changes the trigger from being a PR opened against the `main` branch to trigger on any PR as long as it is not coming from dependabot.