### PR TITLE
Bug - Spinner component w/h visual text

### DIFF
--- a/docs/_includes/markup/spinner.njk
+++ b/docs/_includes/markup/spinner.njk
@@ -1,6 +1,6 @@
 <div class="spinner-border text-info" role="status">
-  <span class="visually-hidden">Loading...</span>
+  <span class="sr-only">Loading...</span>
 </div>
 <div class="spinner-border text-ui" role="status">
-  <span class="visually-hidden">Loading...</span>
+  <span class="sr-only">Loading...</span>
 </div>


### PR DESCRIPTION
Placing correct class onto markup file for Bootstrap version 4.