### PR TITLE
Remove CI workflow on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
Other workflows will fire off when main is merged, which performs the same steps this action does. Removing it from firing on merge to main to cut down on the number of actions running.