### PR TITLE
Underlines in Link

### DIFF
--- a/docs/css/site.css
+++ b/docs/css/site.css
@@ -5,7 +5,9 @@
 .brand-link::after {
   display: none !important;
 }
-
+#resources + ul li a {
+  text-decoration: none;
+}
 .pd-color-block {
   height: 160px;
 }

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -71,12 +71,6 @@
   }
 }
 
-li {
-  a {
-    text-decoration: none;
-  }
-}
-
 .page-header {
   background-color: $white;
   border-bottom: $border-width $border-style $border-color;


### PR DESCRIPTION
Removing underlines from links in text is a bad idea. However, if the links are presented in a list of links (understood to be a list of links), don’t need underlines. In this case it’s ok to remove them, to reduce visual artefacts. To this end, this PR:

- ensures that Resources links don’t have underlines