### PR TITLE
V2 bug - breadcrumb spacing

### DIFF
--- a/docs/_includes/markup/breadcrumbs.njk
+++ b/docs/_includes/markup/breadcrumbs.njk
@@ -2,7 +2,7 @@
   <ol class="breadcrumb">
     <li class="breadcrumb-item">
       <a href="/">
-        <span class="fas fa-home me-1" aria-hidden="true"></span><span class="visually-hidden">Home</span>
+        <span class="fas fa-home" aria-hidden="true"></span><span class="visually-hidden">Home</span>
       </a>
     </li>
     <li class="breadcrumb-item">

--- a/docs/_includes/markup/breadcrumbs.njk
+++ b/docs/_includes/markup/breadcrumbs.njk
@@ -2,7 +2,7 @@
   <ol class="breadcrumb">
     <li class="breadcrumb-item">
       <a href="/">
-        <span class="fas fa-home" aria-hidden="true"></span><span class="visually-hidden">Home</span>
+        <span class="fas fa-home" aria-hidden="true"></span><span class="visually-hidden ms-1">Home</span>
       </a>
     </li>
     <li class="breadcrumb-item">


### PR DESCRIPTION
Accounting for icons near hidden text, only the hidden element should account for any extra spacing needed.