### PR TITLE
V2 bug - table caption

### DIFF
--- a/docs/_includes/markup/table.njk
+++ b/docs/_includes/markup/table.njk
@@ -1,5 +1,5 @@
 <table class="table table-striped">
-  <caption class="visually-hidden">Table caption describes the data presented.</caption>
+  <caption class="visually-hidden position-relative">Table caption describes the data presented.</caption>
   <thead>
     <tr>
       <th scope="col" id="user">


### PR DESCRIPTION
A dark line sit below the header row; this will remove that visual glitch from the top positioning given to the table caption.