### PR TITLE
V2 bug - site slide animation

### DIFF
--- a/docs/css/site.css
+++ b/docs/css/site.css
@@ -10,6 +10,10 @@
   height: 160px;
 }
 
+.container-fluid, .breadcrumb {
+  transition: all 0.2s ease-in-out;
+}
+
 /* adding padding-x at larger sizes */
 /* this applies only to this site */
 @media screen and (min-width: 1200px){


### PR DESCRIPTION
When changing the browser viewport between 1200 px or so, the topbar eases its padding positioning whereas the other main content does not and snaps in place.