### PR TITLE
V2 update - color classes expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@la-ots/pelican",
-  "version": "1.0.0",
+  "version": "2.0.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@la-ots/pelican",
-      "version": "1.0.0",
+      "version": "2.0.0-alpha.1",
       "license": "CC0-1.0",
       "devDependencies": {
         "@11ty/eleventy": "^1.0.0",

--- a/scss/_variables-agency.scss
+++ b/scss/_variables-agency.scss
@@ -191,11 +191,6 @@ $gray-colors: (
 );
 
 
-// MIXIN
-
-// Quickly create utility classes based on the primary map keys;
-// Pass in the map name, secondary key, then the utility class prefix and the attribute to create
-
 @mixin createUtilities($map, $utilityClass, $attribute) {
   @each $primaryKey, $val in $map {
     .#{$utilityClass}-#{$primaryKey} {

--- a/scss/_variables-agency.scss
+++ b/scss/_variables-agency.scss
@@ -9,6 +9,18 @@ $primary-600: #245e8c;
 $primary-700: #104a78;
 $primary-800: #00284d;
 $primary-900: #001646;
+$primary-colors: (
+  primary-50 : $primary-50,
+  primary-100: $primary-100,
+  primary-200: $primary-200,
+  primary-300: $primary-300,
+  primary-400: $primary-400,
+  primary-500: $primary-500,
+  primary-600: $primary-600,
+  primary-700: $primary-700,
+  primary-800: $primary-800,
+  primary-900: $primary-900
+);
 
 // secondary
 $secondary-50 : #eefffc;
@@ -21,6 +33,18 @@ $secondary-600: #00a8a5;
 $secondary-700: #008282;
 $secondary-800: #066769;
 $secondary-900: #0a5757;
+$secondary-colors: (
+  secondary-50 : $secondary-50,
+  secondary-100: $secondary-100,
+  secondary-200: $secondary-200,
+  secondary-300: $secondary-300,
+  secondary-400: $secondary-400,
+  secondary-500: $secondary-500,
+  secondary-600: $secondary-600,
+  secondary-700: $secondary-700,
+  secondary-800: $secondary-800,
+  secondary-900: $secondary-900
+);
 
 // accent
 $accent-50 : #fffaea;
@@ -33,6 +57,18 @@ $accent-600: #e17100;
 $accent-700: #bb4c02;
 $accent-800: #973b09;
 $accent-900: #7c310b;
+$accent-colors: (
+  accent-50 : $accent-50,
+  accent-100: $accent-100,
+  accent-200: $accent-200,
+  accent-300: $accent-300,
+  accent-400: $accent-400,
+  accent-500: $accent-500,
+  accent-600: $accent-600,
+  accent-700: $accent-700,
+  accent-800: $accent-800,
+  accent-900: $accent-900
+);
 
 // success
 $success-50 : #e8ffe6;
@@ -45,6 +81,18 @@ $success-600: #05ab09;
 $success-700: #09820e;
 $success-800: #0d6211;
 $success-900: #115616;
+$success-colors: (
+  success-50 : $success-50,
+  success-100: $success-100,
+  success-200: $success-200,
+  success-300: $success-300,
+  success-400: $success-400,
+  success-500: $success-500,
+  success-600: $success-600,
+  success-700: $success-700,
+  success-800: $success-800,
+  success-900: $success-900
+);
 
 // info
 $info-50 : #ebf9ff;
@@ -57,6 +105,18 @@ $info-600: #0083ff;
 $info-700: #006aff;
 $info-800: #0057d7;
 $info-900: #004ba1;
+$info-colors: (
+  info-50 : $info-50,
+  info-100: $info-100,
+  info-200: $info-200,
+  info-300: $info-300,
+  info-400: $info-400,
+  info-500: $info-500,
+  info-600: $info-600,
+  info-700: $info-700,
+  info-800: $info-800,
+  info-900: $info-900
+);
 
 // warning
 $warning-50 : #ffffea;
@@ -69,6 +129,18 @@ $warning-600: #e29400;
 $warning-700: #bb6902;
 $warning-800: #985108;
 $warning-900: #7c420b;
+$warning-colors: (
+  warning-50 : $warning-50,
+  warning-100: $warning-100,
+  warning-200: $warning-200,
+  warning-300: $warning-300,
+  warning-400: $warning-400,
+  warning-500: $warning-500,
+  warning-600: $warning-600,
+  warning-700: $warning-700,
+  warning-800: $warning-800,
+  warning-900: $warning-900
+);
 
 // dangers
 $danger-50 : #ffefef;
@@ -81,6 +153,18 @@ $danger-600: #ff0004;
 $danger-700: #db0004;
 $danger-800: #b00003;
 $danger-900: #94080a;
+$danger-colors: (
+  danger-50 : $danger-50,
+  danger-100: $danger-100,
+  danger-200: $danger-200,
+  danger-300: $danger-300,
+  danger-400: $danger-400,
+  danger-500: $danger-500,
+  danger-600: $danger-600,
+  danger-700: $danger-700,
+  danger-800: $danger-800,
+  danger-900: $danger-900
+);
 
 // grays
 $gray-50 : #f7f8f8;
@@ -93,3 +177,45 @@ $gray-600: #586a6f;
 $gray-700: #46585d;
 $gray-800: #3a4b50;
 $gray-900: #324348;
+$gray-colors: (
+  gray-50 : $gray-50,
+  gray-100: $gray-100,
+  gray-200: $gray-200,
+  gray-300: $gray-300,
+  gray-400: $gray-400,
+  gray-500: $gray-500,
+  gray-600: $gray-600,
+  gray-700: $gray-700,
+  gray-800: $gray-800,
+  gray-900: $gray-900
+);
+
+
+// MIXIN
+
+// Quickly create utility classes based on the primary map keys;
+// Pass in the map name, secondary key, then the utility class prefix and the attribute to create
+
+@mixin createUtilities($map, $utilityClass, $attribute) {
+  @each $primaryKey, $val in $map {
+    .#{$utilityClass}-#{$primaryKey} {
+      #{$attribute}:#{$val};
+    }
+  }
+}
+@include createUtilities($primary-colors, 'bg', 'background-color');
+@include createUtilities($primary-colors, 'text', 'color');
+@include createUtilities($secondary-colors, 'bg', 'background-color');
+@include createUtilities($secondary-colors, 'text', 'color');
+@include createUtilities($accent-colors, 'bg', 'background-color');
+@include createUtilities($accent-colors, 'text', 'color');
+@include createUtilities($info-colors, 'bg', 'background-color');
+@include createUtilities($info-colors, 'text', 'color');
+@include createUtilities($success-colors, 'bg', 'background-color');
+@include createUtilities($success-colors, 'text', 'color');
+@include createUtilities($warning-colors, 'bg', 'background-color');
+@include createUtilities($warning-colors, 'text', 'color');
+@include createUtilities($danger-colors, 'bg', 'background-color');
+@include createUtilities($danger-colors, 'text', 'color');
+@include createUtilities($gray-colors, 'bg', 'background-color');
+@include createUtilities($gray-colors, 'text', 'color');


### PR DESCRIPTION
In order to utilize any of the color pallets outside the stylesheets, Pelican will provide class equivalents to properties commonly set using similar naming schema to Bootstrap. These are the properties to be accommodated:

- background color / "bg-___"
- color / "text-___"