### PR TITLE
Line lengths, list items

### DIFF
--- a/docs/css/site.css
+++ b/docs/css/site.css
@@ -23,7 +23,15 @@
     padding-right: 14px;
   }
 }
-
 .btns-previous-next {
   margin-top: auto;
+}
+.content-area p:not(.lead), .content-area li {
+  width: 80ch;
+}
+.content-area li {
+  line-height: 1.5;
+}
+.content-area li:not(:last-child) {
+  margin-bottom: .3125rem;
 }


### PR DESCRIPTION
This PR:

- limits paragraph line lengths in the `content-area` to 80 characters maximum
- adjust spacing between list items in the `content-area` for readability