### PR TITLE
Main, Role

### DIFF
--- a/docs/_layouts/default.njk
+++ b/docs/_layouts/default.njk
@@ -9,7 +9,7 @@ layout: base.njk
     <div class="page-content d-flex flex-column">
       {% include "header.njk" %}
       {% include "breadcrumbs.njk" %}
-      <main id="main" class="main" role="main">          
+      <main id="main" class="main">          
         {{ content | safe }}
       </main>
       {% include "footer.njk" %}


### PR DESCRIPTION
This PR removes a redundant attribute and value from a semantic element. A `<main>` doesn’t need `role="main"`.