### PR TITLE
Home hero id error

### DIFF
--- a/docs/index.njk
+++ b/docs/index.njk
@@ -74,7 +74,7 @@ title: Home
   </div>
 </nav>
 
-<div id="" class="hero-dual-pane" style="background-image: url('/img/photos/pexels-photo-275030.jpeg');">
+<div class="hero-dual-pane" style="background-image: url('/img/photos/pexels-photo-275030.jpeg');">
   <div class="overlay overlay-left "></div>
   <div class="overlay overlay-right"></div>
   <div class="container">


### PR DESCRIPTION
This PR removes an empty `id=""` which is flagged by the W3C Validator