### PR TITLE
Adds arial-label to Prev Next buttons

### DIFF
--- a/docs/_includes/markup/buttons-previous-next-page.njk
+++ b/docs/_includes/markup/buttons-previous-next-page.njk
@@ -1,4 +1,4 @@
-<div class="btns-previous-next">
+<div class="btns-previous-next" role="region" aria-label="Move Along This Process">
   <hr class="major">
   <div class="container-fluid">
     <div class="row justify-content-between">

--- a/docs/_includes/markup/page-title.njk
+++ b/docs/_includes/markup/page-title.njk
@@ -12,9 +12,9 @@
       <!-- badges end -->
       <div class="col-12 d-lg-flex justify-content-lg-between align-items-center">
         <div class="mb-2 mb-lg-0">
-          <h2 class="page-title-text">
+          <h1 class="page-title-text" role="presentation">
             <span class="icon fas fa-tachometer-alt mr-1 me-1" aria-hidden="true"></span>Page Title
-          </h2>	
+          </h1>	
           <p class="mb-0">Use this sentence to briefly describe the purpose of the page.</p>
         </div>
         <div>

--- a/docs/components/buttons-previous-next-page.md
+++ b/docs/components/buttons-previous-next-page.md
@@ -14,6 +14,7 @@ eleventyNavigation:
 ## Best Practices
 
 - Place at the bottom, but above the footer, of each page in the process.
+- Be sure to customize the value in the `aria-label="..."` for each project.
 - Buttons should be side by side at small sizes, when the button labels are short.
 - Buttons can be centered at small sizes when the buttons labels are too long for side by side arrangement.
 - When button labels are long enough to require centering, ensure that Previous button is atop the Next button.

--- a/docs/components/page-title.md
+++ b/docs/components/page-title.md
@@ -15,6 +15,7 @@ eleventyNavigation:
 
 - Page Titles tell the user which page they’re on.
 - Pelican recommends a Page Title for every page.
+- Be sure to remove `role="presentation"` from the provided markup.
 - Use the button to provide quick access to one common action for the page.
 - If a page needs more than one button, use a [Bootstrap Dropdown button](https://getbootstrap.com/docs/5.2/components/dropdowns/#single-button).
 - Remove the [Badges](/components/badges/) section if you don’t need them.


### PR DESCRIPTION
This PR:

- adds `aria-label` to the Previous and Next Page buttons
- adds documentation for customizing the aria-label