### PR TITLE
1.2.0 Release Info

### DIFF
--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -16,6 +16,10 @@ You can help improve Pelican. Visit the [Feedback Page](/feedback) to learn how 
 
 We’re continually improving Pelican. The following changes are listed by the date we completed each change.
 
+## 1.2.0 - 01 December 2022
+
+- To be listed...
+
 ## 1.1.2 - 01 July 2022
 
 - Removes underlines from links in a list. [69970834](https://github.com/la-ots/pelican/commit/6997083415837f10ad40445968a5edc86ac48e1f)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@la-ots/pelican",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@la-ots/pelican",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "CC0-1.0",
       "devDependencies": {
         "@11ty/eleventy": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@la-ots/pelican",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Pelican Design System for Louisiana OTS",
   "repository": "git://github.com/la-ots/pelican.git",
   "license": "CC0-1.0",


### PR DESCRIPTION
This will be the content branch dedicated to updating the "What's New" thread and ticking the version number for a new release.