### PR TITLE
V2 Heading Fix

### DIFF
--- a/docs/_includes/markup/page-title.njk
+++ b/docs/_includes/markup/page-title.njk
@@ -12,7 +12,7 @@
       <!-- badges end -->
       <div class="col-12 d-lg-flex justify-content-lg-between align-items-center">
         <div class="mb-2 mb-lg-0">
-          <h1 class="page-title-text" role="presentation">
+          <h1 class="page-title-text">
             <span class="icon fas fa-tachometer-alt mr-1 me-1" aria-hidden="true"></span>Page Title
           </h1>	
           <p class="mb-0">Use this sentence to briefly describe the purpose of the page.</p>

--- a/docs/components/page-title.md
+++ b/docs/components/page-title.md
@@ -15,12 +15,12 @@ eleventyNavigation:
 
 - Page Titles tell the user which page they’re on.
 - Pelican recommends a Page Title for every page.
-- Be sure to remove `role="presentation"` from the provided markup.
 - Use the button to provide quick access to one common action for the page.
 - If a page needs more than one button, use a [Bootstrap Dropdown button](https://getbootstrap.com/docs/5.2/components/dropdowns/#single-button).
 - Remove the [Badges](/components/badges/) section if you don’t need them.
 - Try to keep to just two or three Badges.
 - Badges in the Page Title will appear muted unless they are Danger or Warning Badges.
+- Use only one H1 per page. (We are using an extra one here only as a documentation sample.)
 
 ## Usage
 


### PR DESCRIPTION
This PR fixes a typo on the Page Title component sample in documentation.