### PR TITLE
V2 Tweak Navbars: Changes container-fluid to container

### DIFF
--- a/docs/_includes/markup/navbar-basic.njk
+++ b/docs/_includes/markup/navbar-basic.njk
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-basic">
-  <div class="container-fluid">
+  <div class="container">
     <a class="brand-link" href="#">
       <div class="brand-logo mb-0">{% include 'logo-example.njk' %}</div>
     </a>

--- a/docs/_includes/markup/navbar-iconic.njk
+++ b/docs/_includes/markup/navbar-iconic.njk
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-iconic">
-  <div class="container-fluid">
+  <div class="container">
     <a class="brand-link" href="#">
       <div class="brand-logo">{% include 'logo-example.njk' %}</div>
     </a>

--- a/docs/_includes/markup/navbar-minimal.njk
+++ b/docs/_includes/markup/navbar-minimal.njk
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-minimal">
-  <div class="container-fluid">
+  <div class="container">
     <a class="brand-link" href="#">
       <div class="brand-logo mb-0">{% include 'logo-example.njk' %}</div>
     </a>

--- a/docs/_includes/markup/navbar-search.njk
+++ b/docs/_includes/markup/navbar-search.njk
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-search">
-  <div class="container-fluid">
+  <div class="container">
     <a class="brand-link" href="#">
       <div class="brand-logo mb-0 ">{% include 'logo-example.njk' %}</div>
     </a>
@@ -17,7 +17,7 @@
     </div>
   </div>
   <hr class="minor">
-  <div class="container-fluid">
+  <div class="container">
     <div class="collapse navbar-collapse" id="navigationItemsList">
       <ul class="navbar-nav">
         <li class="nav-item active">


### PR DESCRIPTION
This PR changes the `container-fluid` in the Navbars to just `container` for better alignment with other page blocks.