### PR TITLE
Update area-page.njk

### DIFF
--- a/docs/_layouts/area-page.njk
+++ b/docs/_layouts/area-page.njk
@@ -13,7 +13,7 @@ layout: default.njk
             <div class="card mb-0 shadow-none h-100">
               <div class="card-body">
                 {%- if child.img %}
-                <img alt="" src="{{ child.img }}" class="img-fluid mb-3 gray-hover-color" aria-hidden="true"/>
+                <img alt="" src="{{ child.img }}" class="w-100 mb-3 gray-hover-color" aria-hidden="true"/>
                 {%- endif %}
                 <a href="{{ child.url }}" class="text-decoration-none d-flex align-items-center stretched-link mt-auto">
                   {{ child.title }}<span class="fas fa-arrow-right ml-auto ms-auto opacity-25" aria-hidden="true"></span>                


### PR DESCRIPTION
This update to the area-page layout makes the card images’ widths fit the width of the parent.