### PR TITLE
V2 Version Switcher

### DIFF
--- a/docs/_includes/header.njk
+++ b/docs/_includes/header.njk
@@ -6,6 +6,22 @@
     </a>
     <span class="d-none d-md-inline" tabindex="-1">{{ title }}</span>
   </p>
+  <div class="dropdown">
+    <button class="btn btn-link dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+      {# this text should change to reflect the version #}
+      {# swapping the .d- classes will work #}
+      <span class="d-inline">v1.1.2</span>
+      <span class="d-none">v2.0</span>
+    </button>
+    <ul class="dropdown-menu">
+      <li>
+        <a class="dropdown-item" href="#">v1.1.2</a>
+      </li>
+      <li>
+        <a class="dropdown-item" href="#">v2.0</a>
+      </li>
+    </ul>
+  </div>
   <button id="sidebar-button" class="btn btn-sm btn-black sidebar-button" aria-haspopup="true" aria-controls="sidebar" tabindex="3">
     <span class="icon fas fa-fw fa-bars" aria-hidden="true"></span>
     <span class="visually-hidden">Toggle side navigation</span>

--- a/docs/_includes/header.njk
+++ b/docs/_includes/header.njk
@@ -6,7 +6,7 @@
     </a>
     <span class="d-none d-md-inline" tabindex="-1">{{ title }}</span>
   </p>
-  <div class="dropdown">
+  <div class="dropdown order-lg-3">
     <button class="btn btn-link dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
       {# this text should change to reflect the version #}
       {# swapping the .d- classes will work #}

--- a/docs/index.njk
+++ b/docs/index.njk
@@ -73,6 +73,10 @@ title: Home
   </div>
 </nav>
 
+<div role="alert" class="alert alert-accent bg-accent text-black border-0 rounded-0 mb-0 text-center">
+  <span class="fw-bold">Introducing Pelican 2!</span><br class="d-block d-md-none"> You can still get <a href="#" class="text-black">Pelican 1</a> if you need it.
+</div>
+
 <section class="hero-dual-pane" style="background-image: url('/img/photos/pexels-photo-275030.jpeg');" role="banner" aria-label="Pelican Design System">
   <div class="overlay overlay-left"></div>
   <div class="overlay overlay-right"></div>

--- a/scss/_sidebar.scss
+++ b/scss/_sidebar.scss
@@ -313,17 +313,41 @@ main.main {
 .wrapper-topbar {
   position: sticky;
   position: -webkit-sticky;
-  top: 0;
-  left: 0;
+  top: 0; left: 0;
   z-index: 900;
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  width: 100%;
-  height: 40px;
+  width: 100%; height: 40px;
   padding: 0.25rem 0.5rem;
-  color:            var(--theme-topbar-text-color);
-  background-color: var(--theme-topbar-bg-color);
+  color:                  var(--theme-topbar-text-color);
+  background-color:       var(--theme-topbar-bg-color);
+  .dropdown {
+    .dropdown-toggle {
+      color:              var(--theme-topbar-text-color);
+    }
+    .dropdown-menu {
+      background-color:   var(--theme-topbar-bg-color);
+      border: 0;
+      border-top: 1px solid white;
+      &::before {
+        content: '';
+        position: absolute;
+        width: 0; height: 0;
+        top: -.35rem; right: .75rem;
+        border-style: solid;
+        border-width: 0 .3rem .3rem .3rem;
+        border-color: transparent transparent var(--theme-topbar-text-color) transparent;
+      }
+    }
+    .dropdown-item {
+      color:              var(--theme-topbar-text-color);
+      &:hover, &:focus {
+        background-color: var(--theme-topbar-text-color);
+        color:            var(--theme-topbar-bg-color);
+      }
+    }
+  }
   img {
     height: 24px;
   }


### PR DESCRIPTION
This PR:

- Creates a message on the home page to indicate that Pelican 2 is the default, canonical version for the docs
- Adds a link in the message for navigating to Pelican 1
- Creates a dropdown button to enable users to switch between docs versions
- Adds necessary SCSS / CSS Variables