### PR TITLE
Card Borders Adjusted

### DIFF
--- a/scss/_default-theme-variables.scss
+++ b/scss/_default-theme-variables.scss
@@ -215,6 +215,7 @@
   --theme-card-bg-color       : var(--bs-white);
   --theme-card-nested-bg-color: var(--theme-gray-50);
   --theme-card-border-color   : var(--theme-gray-200);
+  --theme-card-border-width   : .0625rem;
 
   /* content-container */
   --theme-content-container-bg-color            : var(--bs-white);

--- a/scss/_default-theme.scss
+++ b/scss/_default-theme.scss
@@ -236,7 +236,7 @@ $breadcrumb-divider-color: var(--theme-breadcrumb-divider-color);
 // Cards
 $card-spacer-y: 1rem;
 $card-spacer-x: 1rem;
-$card-border-width: var(--theme-border-width) !default;
+$card-border-width: var(--theme-card-border-width) !default;
 $card-border-radius: $border-radius !default;
 $card-border-color: var(--theme-card-border-color);
 $card-inner-border-radius: calc(#{$card-border-radius} - #{$card-border-width}) !default;


### PR DESCRIPTION
This PR adjusts cards’ borders to be slightly thinner. This allows more important borders such as form fields to get a little more visual attention.

![Original card border width](https://github.com/la-ots/pelican/assets/10730801/324668c4-64e5-437f-b626-2286ee7284c1)
![Adjusted card border width](https://github.com/la-ots/pelican/assets/10730801/4c3ccfe7-593d-4c65-b0e7-52d9503376ae)
