### PR TITLE
V2 Table Stripes

### DIFF
--- a/scss/_default-theme-variables.scss
+++ b/scss/_default-theme-variables.scss
@@ -357,6 +357,7 @@
   --theme-table-border-width      : 1px
   --theme-table-border-width-thick: 3px;
   --theme-table-cell-padding      : .5rem;
+  --theme-table-striped-bg        : var(--theme-gray-50);
 
   /* toasts */
   --theme-toast-header-success-bg-color  : var(--theme-success-100);

--- a/scss/_default-theme-variables.scss
+++ b/scss/_default-theme-variables.scss
@@ -357,7 +357,7 @@
   --theme-table-border-width      : 1px
   --theme-table-border-width-thick: 3px;
   --theme-table-cell-padding      : .5rem;
-  --theme-table-striped-bg        : var(--theme-gray-50);
+  --theme-table-striped-bg        : var(--theme-gray-50) / 2;
 
   /* toasts */
   --theme-toast-header-success-bg-color  : var(--theme-success-100);

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -1,19 +1,20 @@
 caption {
   caption-side: bottom;
-  border-top: 1px dashed var(--theme-ui);
+  border-top: 1px dashed var(--theme-border-color);
 }
 .table {
   width: 100%;
   margin-bottom: 1rem;
   font-size: $font-size-base * 0.875;
   color:            var(--theme-gray-700);
-  background-color: var(--theme-gray-white); // Reset for nesting within parents with `background-color`.
+  background-color: var(--theme-gray-white);
   border-color: var(--theme-table-border-color);
   th,
   td {
     padding         : var(--theme-table-cell-padding);
     vertical-align  : top;
     border-top-width: var(--theme-table-border-width);
+    background-color: var(--theme-gray-white);
   }
   thead th {
     vertical-align: bottom;
@@ -45,5 +46,10 @@ caption {
         border-bottom-right-radius: 4px;
       }
     }
+  }
+}
+.table-striped {
+  > tbody > tr:nth-of-type(odd) > * {
+    background-color: var(--theme-table-striped-bg);
   }
 }

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -47,9 +47,12 @@ caption {
       }
     }
   }
+  > :not(caption) > * > * {
+    border-bottom-width: 0;
+  }
 }
 .table-striped {
-  > tbody > tr:nth-of-type(odd) > * {
-    background-color: var(--theme-table-striped-bg);
+  > tbody > tr:nth-of-type(#{$table-striped-order}) > * {
+    --#{$prefix}table-bg-type: var(--theme-table-striped-bg);
   }
 }


### PR DESCRIPTION
This PR returns table striping and border thickness to pre 5.3 import.

Old

![old](https://github.com/la-ots/pelican/assets/10730801/b5a0ce5f-a2a9-4be8-962e-a8c32b4daf87)

New

![new](https://github.com/la-ots/pelican/assets/10730801/c8d5060b-c5a5-4e6f-84a7-fc0442097546)
