### PR TITLE
V2 Area Page Tweaks

### DIFF
--- a/docs/_layouts/area-page.njk
+++ b/docs/_layouts/area-page.njk
@@ -15,8 +15,9 @@ layout: default.njk
                 {%- if child.img %}
                 <img alt="" src="{{ child.img }}" class="w-100 mb-3 gray-hover-color" aria-hidden="true"/>
                 {%- endif %}
-                <a href="{{ child.url }}" class="text-decoration-none d-flex align-items-center stretched-link mt-auto">
-                  {{ child.title }}<span class="fas fa-arrow-right ml-auto ms-auto opacity-25" aria-hidden="true"></span>                
+                <a href="{{ child.url }}" class="stretched-link area-page-link">
+                  <span class="icon fas fa-arrow-right me-2" aria-hidden="true"></span> 
+                  {{ child.title }}          
                 </a>
               </div>
             </div>

--- a/docs/css/site.css
+++ b/docs/css/site.css
@@ -8,18 +8,6 @@
 .pd-color-block {
   height: 160px;
 }
-/* adding padding-x at larger sizes */
-/* this applies only to this site */
-@media screen and (min-width: 1200px){
-  .container-fluid {
-    padding-right: 24px;
-    padding-left:  24px;
-  }
-  .wrapper-topbar {
-    padding-left:  14px;
-    padding-right: 14px;
-  }
-}
 .btns-previous-next {
   margin-top: auto;
 }
@@ -33,4 +21,37 @@
 .content-area li:not(:last-child),
 .content-area li:not(:list-group-item) {
   margin-bottom: .3125rem;
+}
+.area-page-link {
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  margin-top: auto;
+  position: relative;
+  padding-left: 1.375rem;
+}
+.area-page-link .icon {
+  position: absolute;
+  left: 0; top: .1875rem;
+  transition: opacity 100ms ease-out;
+  opacity: .5;
+}
+.area-page-link:hover {
+  text-decoration: underline;
+}
+.area-page-link:hover .icon {
+  opacity: 1;
+}
+
+/* adding padding-x at larger sizes */
+/* this applies only to this site */
+@media screen and (min-width: 1200px){
+  .container-fluid {
+    padding-right: 24px;
+    padding-left:  24px;
+  }
+  .wrapper-topbar {
+    padding-left:  14px;
+    padding-right: 14px;
+  }
 }


### PR DESCRIPTION
This PR applies a slight visual design refactor to the cards on the area page.

The cards have a faint arrow to the right of the link text. When hovered, the icon gets an underline which doesn’t fit well with the icons’ visual design. This refactor positions the icons to the left of the link text and in a way to exclude them from the underline upon hover.

Old
![old](https://github.com/la-ots/pelican/assets/10730801/4f8c07f7-5b28-4e92-9a73-e1f3a1a915b7)

New
![new](https://github.com/la-ots/pelican/assets/10730801/a5aa0311-f755-4a6e-ab17-11d3741b940f)
