### PR TITLE
Fix ARIA for TOC

### DIFF
--- a/docs/_includes/markup/documentation-internal.njk
+++ b/docs/_includes/markup/documentation-internal.njk
@@ -8,7 +8,7 @@
             <summary class="summary">
               <h2 class="h6 d-inline" id="on-this-page">On this page:</h2>
             </summary>
-            <nav aria-labelledby=“on-this-page”>
+            <nav aria-labelledby="on-this-page">
               <div class="toc">
                 <ol>
                   <li><a href="#">Heading X</a>

--- a/docs/_includes/markup/documentation-public.njk
+++ b/docs/_includes/markup/documentation-public.njk
@@ -8,7 +8,7 @@
             <summary class="summary">
               <h2 class="h6 d-inline" id="on-this-page">On this page:</h2>
             </summary>
-            <nav aria-labelledby=“on-this-page”>
+            <nav aria-labelledby="on-this-page">
               <div class="toc">
                 <ol>
                   <li><a href="#">Heading X</a>

--- a/docs/_includes/markup/sample-toc.njk
+++ b/docs/_includes/markup/sample-toc.njk
@@ -4,7 +4,7 @@
       <summary class="summary">
         <h2 class="h6 d-inline" id="on-this-page">On this page:</h2>
       </summary>
-      <nav aria-labelledby=“on-this-page”>
+      <nav aria-labelledby="on-this-page">
         <div class="toc">
           <ol>
             <li>

--- a/docs/_includes/page-contents.njk
+++ b/docs/_includes/page-contents.njk
@@ -4,7 +4,7 @@
       <summary class="summary">
         <h2 class="h6 d-inline" id="on-this-page">On this page:</h2>
       </summary>
-      <nav aria-labelledby=“on-this-page”>
+      <nav aria-labelledby="on-this-page">
         {{content | toc | safe }}
       </nav>
     </details>


### PR DESCRIPTION
The existing implementation used curly quotes around the `aria-labelledby` attribute, making it a broken ARIA reference. This PR replaces the curly quotes with straight quotes.