### PR TITLE
Pagination Accessibility

### DIFF
--- a/docs/_includes/markup/pagination.njk
+++ b/docs/_includes/markup/pagination.njk
@@ -1,7 +1,7 @@
 <div class="row justify-content-center align-items-md-end">
   <div class="col-md-3">
     <form action="sampleAction" class="">
-      <label class="d-none" aria-hidden="false" for="NumberItemsToShow">Show how many?</label>
+      <label class="visually-hidden" for="NumberItemsToShow">Show how many?</label>
       <select class="custom-select form-select mb-4 mb-lg-0" aria-label="" id="NumberItemsToShow">
         <option selected>Show 10 per page</option>
         <option value="1">Show 25 per page</option>


### PR DESCRIPTION
This PR resolves a contradictory use of accessibility techniques between Display styles and ARIA attributes.

- Changes `d-none` to `visually-hidden`
- Removes `aria-hidden='false'`