### PR TITLE
Add Figma Link

### DIFF
--- a/docs/index.njk
+++ b/docs/index.njk
@@ -66,7 +66,10 @@ title: Home
           <a class="nav-link" href="/feedback/">Feedback</a>
         </li>
         <li class="nav-item">
-          <a class="btn btn-white" href="/accessibility/accessibility-statement/">Accessibility Statement</a>
+          <a class="nav-link" href="/accessibility/accessibility-statement/">Accessibility</a>
+        </li>
+        <li class="nav-item">
+          <a class="btn btn-white" href="https://www.figma.com/community/file/1295790757134814477/pelican-2">Figma Library</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
This PR adds a link to the Figma library at Figma Community Nav on the home page nav.