### PR TITLE
Adds Link and Hover Styles

### DIFF
--- a/docs/_includes/markup/table.njk
+++ b/docs/_includes/markup/table.njk
@@ -3,13 +3,13 @@
   <thead>
     <tr>
       <th scope="col" id="user">
-        <a href="#" class="text-decoration-none" role="button">
+        <a href="#" role="button">
           <span class="icon fas fa-sort me-1" aria-hidden="true"></span>User
           <span class="visually-hidden">Sort the table by the data of this user column</span>
         </a>
       </th>
       <th scope="col" id="role">
-        <a href="#" class="text-decoration-none" role="button">
+        <a href="#" role="button">
           <span class="icon fas fa-sort me-1" aria-hidden="true"></span>Role
           <span class="visually-hidden">Sort the table by the data of this role column</span>
         </a>
@@ -18,7 +18,7 @@
         Figma Trained
       </th>
       <th scope="col" id="team">
-        <a href="#" class="text-decoration-none" role="button">
+        <a href="#" role="button">
           <span class="icon fas fa-sort me-1" aria-hidden="true"></span>Team
           <span class="visually-hidden">Sort the table by the data of this team column</span>
         </a>

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -16,10 +16,15 @@ You can help improve Pelican. Visit the [Feedback Page](/feedback) to learn how 
 
 We’re continually improving Pelican. The following changes are listed by the date we completed each change.
 
-## 2.0.1 – 27 November 2023
+## 2.0.2 – 28 November 2023
 
 - Links in tables get underlines, and double underlines on hover, by default for accessibility.
 - Sidebar button gets a hover state border change
+- Removes text selection styles and variables
+
+## 2.0.1 - 23 October 2023
+
+- Added additional theming variables
 
 ## 2.0.0 – 16 October 2023
 

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -16,7 +16,12 @@ You can help improve Pelican. Visit the [Feedback Page](/feedback) to learn how 
 
 We’re continually improving Pelican. The following changes are listed by the date we completed each change.
 
-## 2.0.0 - 16 October 2023
+## 2.0.1 – 27 November 2023
+
+- Links in tables get underlines, and double underlines on hover, by default for accessibility.
+- Sidebar button gets a hover state border change
+
+## 2.0.0 – 16 October 2023
 
 - **Bootstrap 5.** Bootstrap updated from version 4 to version 5. Pelican 2 is based upon Bootstrap 5.2 but Pelican 1 is based upon Bootstrap 4.6. This major change in Bootstrap version required some things to be refactored in the code to accommodate this. See the [Migration Guide](/migration-guide/) for details about how this affects projects built upon Pelican 1 (Bootstrap 4.6).
 - **CSS Variables.** Easier code theming for dependent projects. Bootstrap 5 introduces the use of CSS variables to enable better theming flexibility. Be sure to tell your developer.

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -119,6 +119,9 @@ a.btn {
   position: relative;
   margin-right: 0.25rem;
   color: var(--theme-topbar-text-color);
+  &:hover {
+    border-color: var(--theme-topbar-text-color);
+  }
   @media screen and (min-width: 992px) {
     order: 1;
   }

--- a/scss/_reboot.scss
+++ b/scss/_reboot.scss
@@ -74,8 +74,7 @@ hr,
 }
 
 // Added for links, but not button style, in paragraph text or list items
-p,
-li {
+p, li, table {
   a {
     //text-decoration-line      : var(--theme-text-decoration-line);
     //text-decoration-style     : var(--theme-text-decoration-style);
@@ -85,10 +84,9 @@ li {
       text-decoration-style: double;
     }
     &.btn {
-      text-decoration: none;
       &:hover,
       &:active {
-        text-decoration: none;
+        text-decoration: double;
       }
     }
   }


### PR DESCRIPTION
This PR improves accessibility by:
- Putting underlines on links in tables
- Changing underlines to double underlines on hover to links in tables
- Adding a border change to the sidebar button on hover

![links-1](https://github.com/la-ots/pelican/assets/10730801/8d87f69f-fffe-4b52-af4a-1f3d470819c2)
![links-2](https://github.com/la-ots/pelican/assets/10730801/af419420-d648-4461-a65d-d9de1f63f458)

![sidebar-button-1](https://github.com/la-ots/pelican/assets/10730801/98848836-9624-4800-8dcf-de699f1a25e6)
![sidebar-button-2](https://github.com/la-ots/pelican/assets/10730801/226414c8-053f-44ad-a66d-955cc9f16678)

