### PR TITLE
Vertical Centers for List Group Link Icons

### DIFF
--- a/docs/components/list-group.md
+++ b/docs/components/list-group.md
@@ -44,7 +44,7 @@ eleventyNavigation:
 <div class="list-group" role="list-group">
   <a role="list-item" href="#" class="list-group-item list-group-item-action">An item</a>
   <a role="list-item" href="#" class="list-group-item list-group-item-action">A second item</a>
-  <a role="list-item" href="#" class="list-group-item list-group-item-action">A thirditem</a>
+  <a role="list-item" href="#" class="list-group-item list-group-item-action">A third item</a>
   <a role="list-item" href="#" class="list-group-item list-group-item-action">A fourth item</a>
   <a role="list-item" href="#" class="list-group-item list-group-item-action">And a fifth one</a>
 </div>
@@ -54,7 +54,7 @@ eleventyNavigation:
 <div class="list-group" role="list-group">
   <a role="list-item" href="#" class="list-group-item list-group-item-action">An item</a>
   <a role="list-item" href="#" class="list-group-item list-group-item-action">A second item</a>
-  <a role="list-item" href="#" class="list-group-item list-group-item-action">A thirditem</a>
+  <a role="list-item" href="#" class="list-group-item list-group-item-action">A third item</a>
   <a role="list-item" href="#" class="list-group-item list-group-item-action">A fourth item</a>
   <a role="list-item" href="#" class="list-group-item list-group-item-action">And a fifth one</a>
 </div>

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -16,6 +16,10 @@ You can help improve Pelican. Visit the [Feedback Page](/feedback) to learn how 
 
 We’re continually improving Pelican. The following changes are listed by the date we completed each change.
 
+## 2.0.3 – November 2023
+
+- Icons in List Group links are vertically centered
+
 ## 2.0.2 – 28 November 2023
 
 - Links in tables get underlines, and double underlines on hover, by default for accessibility.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@la-ots/pelican",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "CC0-1.0",
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Pelican Design System for Louisiana OTS",
   "repository": "git://github.com/la-ots/pelican.git",
   "license": "CC0-1.0",

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -17,6 +17,6 @@
     font-style: normal;
     font-weight: 900;
     font-variant: normal;
-    margin: 0 1px 0 5px;
+    margin: .25rem 0.0625rem 0 0.3125rem;
   }
 }


### PR DESCRIPTION
This PR adjusts the vertical position of the icons in the links of List Groups. This makes the icons vertically-centered. It closes #545 

![ScreenShot 2023-11-30 at 09 05 43](https://github.com/la-ots/pelican/assets/10730801/5db0a75c-a957-4258-bba6-d927eb728f23)
![ScreenShot 2023-11-30 at 09 06 14](https://github.com/la-ots/pelican/assets/10730801/9f2ceb26-b38e-4b1c-aecd-d8639a3df137)
