### PR TITLE
V2 CSS Variable Additions

### DIFF
--- a/docs/_includes/markup/app-screen.njk
+++ b/docs/_includes/markup/app-screen.njk
@@ -52,7 +52,7 @@
   <div id="wrapper-main" class="wrapper-main">
     <div class="page-content">
       <!-- topbar -->
-      <div id="wrapper-topbar" class="wrapper-topbar bg-black text-white">
+      <div id="wrapper-topbar" class="wrapper-topbar">
         <p class="m-0 fw-bold order-lg-2 me-auto">
           <a href="#" class="d-md-none text-white text-decoration-none" tabindex="2">
             <span class="d-md-none">Digital Product Name</span>

--- a/docs/components/list-group.md
+++ b/docs/components/list-group.md
@@ -44,7 +44,7 @@ eleventyNavigation:
 <div class="list-group" role="list-group">
   <a role="list-item" href="#" class="list-group-item list-group-item-action">An item</a>
   <a role="list-item" href="#" class="list-group-item list-group-item-action">A second item</a>
-  <a role="list-item" href="#" class="list-group-item list-group-item-action">A thirditem</a>
+  <a role="list-item" href="#" class="list-group-item list-group-item-action">A third item</a>
   <a role="list-item" href="#" class="list-group-item list-group-item-action">A fourth item</a>
   <a role="list-item" href="#" class="list-group-item list-group-item-action">And a fifth one</a>
 </div>
@@ -54,7 +54,7 @@ eleventyNavigation:
 <div class="list-group" role="list-group">
   <a role="list-item" href="#" class="list-group-item list-group-item-action">An item</a>
   <a role="list-item" href="#" class="list-group-item list-group-item-action">A second item</a>
-  <a role="list-item" href="#" class="list-group-item list-group-item-action">A thirditem</a>
+  <a role="list-item" href="#" class="list-group-item list-group-item-action">A third item</a>
   <a role="list-item" href="#" class="list-group-item list-group-item-action">A fourth item</a>
   <a role="list-item" href="#" class="list-group-item list-group-item-action">And a fifth one</a>
 </div>

--- a/docs/css/your-theme.css
+++ b/docs/css/your-theme.css
@@ -237,9 +237,6 @@
 
   --theme-focus-color: #2491ff;
 
-  /* form validation */
-  --theme-form-validation-error-muted-color: var(--theme-danger-200);
-
   /* feature blocks */
   /* you may need still need to change the classes on buttons */
 
@@ -272,6 +269,11 @@
   --theme-form-input-shadow-color: var(--theme-ui-light);
   --theme-input-btn-focus-color: var(--theme-focus-color);
   --theme-form-active-color: var(--theme-ui-priority);
+  --theme-form-check-input-checked-bg-color: var(--theme-ui-priority);
+  --theme-form-check-input-checked-border-color: var(--theme-ui-priority);
+
+  /* form validation */
+    --theme-form-validation-error-muted-color: var(--theme-danger-200);
 
   /* footers */
   /* you may need still need to change the classes on buttons */

--- a/docs/css/your-theme.css
+++ b/docs/css/your-theme.css
@@ -164,6 +164,8 @@
   /* 4. Set the properties for Bootstrap and Pelican items */
   /* alerts */
 
+  --theme-alert-border-radius: .25rem;
+
   --theme-alert-success-text-color: var(--theme-success-900);
   --theme-alert-success-bg-color: var(--theme-success-100);
   --theme-alert-success-border-color: var(--theme-success-900);
@@ -265,6 +267,7 @@
 
   --theme-feature-languages-bg-color: var(--theme-accent);
   --theme-feature-languages-text-color: var(--theme-primary);
+  --theme-feature-languages-item-text-color: var(--theme-primary);
   --theme-feature-languages-item-bg-color: var(--theme-gray-white);
 
   --theme-feature-many-icons-text-bg-color: var(--theme-primary);
@@ -283,6 +286,7 @@
   --theme-form-input-shadow-color: var(--theme-ui-light);
   --theme-input-btn-focus-color: var(--theme-focus-color);
   --theme-form-active-color: var(--theme-ui-priority);
+  --theme-form-check-input-color: var(--theme-gray-white);
   --theme-form-check-input-checked-bg-color: var(--theme-ui-priority);
   --theme-form-check-input-checked-border-color: var(--theme-ui-priority);
 
@@ -328,6 +332,7 @@
 
   /* List Groups */
 
+  --theme-list-group-link-color: var(--theme-link-color);
   --theme-list-group-bg: var(--theme-card-bg-color);
   --theme-list-group-border-color: var(--theme-card-border-color);
 
@@ -355,6 +360,7 @@
 
   --theme-official-banner-text-color: var(--theme-gray-white);
   --theme-official-banner-bg: var(--theme-gray-black);
+  --theme-official-banner-focus-indicator-color: var(--theme-gray-white);
 
   /* page header, title */
 
@@ -368,6 +374,7 @@
   --theme-pagination-color: var(--theme-link-color);
   --theme-pagination-hover-color: var(--theme-link-color);
   --theme-pagination-active-color: var(--theme-link-color);
+  --theme-pagination-border-color: var(--theme-border-color-lighter);
 
   /* popovers and tooltips */
 

--- a/docs/css/your-theme.css
+++ b/docs/css/your-theme.css
@@ -13,6 +13,9 @@
   /* 5. Apply colors to the buttons */
   /* 6. Save file! */
 
+  
+
+
   /* 1. First enter all palette colors for the categories */
   /* palette colors */
 
@@ -122,6 +125,9 @@
   --theme-gray-900: #324348;
   --theme-gray-black: #000000;
 
+
+
+
   /* 2. Assign the semantic colors from a color in the preceeding categories */
   /* semantic colors */
 
@@ -140,6 +146,9 @@
   --theme-body-bg: var(--theme-gray-50);
   --bs-body-color: var(--theme-gray-900);
 
+
+
+
   /* 3. Set properties which are shared */
   /* borders */
 
@@ -148,6 +157,9 @@
   --theme-border-width: 0.125rem;
   --theme-border-style: solid;
   --bs-border-color: var(--theme-ui);
+
+
+
 
   /* 4. Set the properties for Bootstrap and Pelican items */
   /* alerts */
@@ -197,6 +209,7 @@
 
   --theme-badge-chip-warning-bg-color: var(--theme-warning);
   --theme-badge-chip-warning-text-color: var(--bs-black);
+
   --theme-badge-chip-danger-bg-color: var(--theme-danger);
   --theme-badge-chip-danger-text-color: var(--theme-gray-white);
 
@@ -226,6 +239,7 @@
   --theme-card-bg-color: var(--theme-gray-white);
   --theme-card-nested-bg-color: var(--theme-gray-50);
   --theme-card-border-color: var(--theme-border-color-lighter);
+  --theme-card-border-width: .0625rem;
 
   /* content-container */
 
@@ -345,9 +359,15 @@
   /* page header, title */
 
   --theme-page-title-bg-color: var(--theme-gray-white);
-  --theme-page-title-text-color: var(--theme-primary);
+  --theme-page-title-text-color: var(--theme-text-headings-color);
   --theme-page-title-icon-color: var(--theme-page-title-text-color);
   --theme-page-title-border-color: var(--theme-border-color-lighter);
+
+  /* pagination */
+
+  --theme-pagination-color: var(--theme-link-color);
+  --theme-pagination-hover-color: var(--theme-link-color);
+  --theme-pagination-active-color: var(--theme-link-color);
 
   /* popovers and tooltips */
 
@@ -362,13 +382,13 @@
   /* progress */
 
   --theme-progress-border-color: var(--theme-border-color-lighter);
-  --theme-progress-bg-color: var(--theme-gray-white);
-  --theme-progress-description-color: var(--theme-primary);
-  --theme-progress-description-counter-color: var(--theme-primary);
-  --theme-progress-description-text-color: var(--theme-primary);
-  --theme-progress-step-bg-color: var(--theme-primary);
-  --theme-progress-step-border-color: var(--theme-primary);
-  --theme-progress-step-digit-color: var(--theme-gray-white);
+	--theme-progress-bg-color: var(--theme-gray-white);
+	--theme-progress-description-color: var(--theme-text-headings-color);
+	--theme-progress-description-counter-color: var(--theme-text-headings-color);
+	--theme-progress-description-text-color: var(--theme-text-headings-color);
+	--theme-progress-step-bg-color: var(--theme-text-headings-color);
+	--theme-progress-step-border-color: var(--theme-text-headings-color);
+	--theme-progress-step-digit-color: var(--theme-gray-white);
 
   /* sidebar & topbar */
 
@@ -378,6 +398,7 @@
   --theme-sidebar-wrapper-bg-color: var(--theme-primary);
   --theme-sidebar-header-border-color: var(--theme-primary-900);
   --theme-sidebar-link-color: var(--bs-white);
+  --theme-sidebar-link-hover-color: var(--theme-gray-white);
   --theme-sidebar-item-bg-color: var(--theme-info);
   --theme-sidebar-submenu-bg-color: var(--theme-primary-900);
 
@@ -391,8 +412,9 @@
   --theme-table-border-width: 1px;
   --theme-table-border-width-thick: 3px;
   --theme-table-cell-padding: 0.5rem;
-  --theme-table-stripe-bg: var(--theme-body-bg);
+  --theme-table-striped-bg: var(--theme-body-bg);
   --theme-table-border-color: var(--theme-border-color-lighter);
+  --bs-pagination-bg: var(--theme-gray-white);
 
   /* toasts */
 
@@ -428,15 +450,17 @@
 
   --theme-small-text-color: var(--theme-gray-700);
   --theme-blockquote-bg-color: var(--theme-ui-light);
-  --theme-blockquote-order-color: var(--theme-ui);
+  --theme-blockquote-border-color: var(--theme-ui);
   --theme-bolded-text-color: var(--themegray--black);
-  --theme-table-striped-bg: var(--theme-gray-50);
   --theme-text-selection-text-color: var(--theme-primary-700);
   --theme-text-selection-bg-color: var(--theme-primary-200);
   --theme-text-decoration-line: underline;
   --theme-text-decoration-style: dashed;
   --theme-text-decoration-color: var(--theme-info-500);
   --theme-text-decoration-thickness: var(--theme-border-width);
+  --theme-text-headings-color: var(--theme-primary);
+  --bs-body-font-family: var(--theme-font-family);
+  --bs-heading-color: var(--theme-text-headings-color);
 }
 
 /* rules begin */

--- a/docs/css/your-theme.css
+++ b/docs/css/your-theme.css
@@ -125,9 +125,6 @@
   --theme-gray-900: #324348;
   --theme-gray-black: #000000;
 
-
-
-
   /* 2. Assign the semantic colors from a color in the preceeding categories */
   /* semantic colors */
 
@@ -145,9 +142,7 @@
   --theme-text-normal: var(--theme-gray-700);
   --theme-body-bg: var(--theme-gray-50);
   --bs-body-color: var(--theme-gray-900);
-
-
-
+  --bs-body-bg: var(--theme-body-bg);
 
   /* 3. Set properties which are shared */
   /* borders */
@@ -156,10 +151,7 @@
   --theme-border-color-lighter: var(--theme-ui-light);
   --theme-border-width: 0.125rem;
   --theme-border-style: solid;
-  --bs-border-color: var(--theme-ui);
-
-
-
+  --bs-border-color: var(--theme-border-color);
 
   /* 4. Set the properties for Bootstrap and Pelican items */
   /* alerts */
@@ -194,6 +186,11 @@
   --theme-badge-chip-secondary-bg-dim-color: var(--theme-secondary-900);
   --theme-badge-chip-secondary-text-dim-color: var(--theme-secondary-100);
 
+  --theme-badge-chip-accent-bg-color: var(--theme-accent);
+  --theme-badge-chip-accent-text-color: var(--theme-gray-black);
+  --theme-badge-chip-accent-bg-dim-color: var(--theme-accent-100);
+  --theme-badge-chip-accent-text-dim-color: var(--theme-accent-900);
+
   --theme-badge-chip-ui-bg-color: var(--theme-ui);
   --theme-badge-chip-ui-text-color: var(--theme-gray-white);
   --theme-badge-chip-ui-bg-dim-color: var(--theme-ui-900);
@@ -222,10 +219,6 @@
   --theme-breadcrumb-border-color: var(--theme-ui-light);
   --theme-breadcrumb-link-color: var(--theme-link-color);
   --theme-breadcrumb-active-color: var(--theme-gray-black);
-
-  /* body */
-
-  --bs-body-bg: var(--theme-body-bg);
 
   /* buttons */
 
@@ -328,7 +321,7 @@
 
   /* HR, dividers */
 
-  --theme-divider-bg-color: var(--theme-ui-light);
+  --theme-divider-bg-color: var(--theme-border-color-lighter);
 
   /* List Groups */
 
@@ -416,8 +409,8 @@
 
   /* tables */
 
-  --theme-table-border-width: 1px;
-  --theme-table-border-width-thick: 3px;
+  --theme-table-border-width: 0.0625rem;
+  --theme-table-border-width-thick: 0.1875rem;
   --theme-table-cell-padding: 0.5rem;
   --theme-table-striped-bg: var(--theme-body-bg);
   --theme-table-border-color: var(--theme-border-color-lighter);
@@ -455,6 +448,8 @@
 
   /* typography and related colors */
 
+  /* you will need to provide a font reference if you override the default */
+  --theme-font-family: "Public Sans", "Public SansVariable", -apple-system, blinkmacsystemfont, "Segoe UI", "Helvetica Neue", "Arial", "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --theme-small-text-color: var(--theme-gray-700);
   --theme-blockquote-bg-color: var(--theme-ui-light);
   --theme-blockquote-border-color: var(--theme-ui);

--- a/docs/css/your-theme.css
+++ b/docs/css/your-theme.css
@@ -418,6 +418,7 @@
 
   /* toc */
 
+  --theme-toc-header-color: var(--bs-heading-color);
   --theme-toc-link-color: var(--theme-link-color);
   --theme-toc-link-hover-color: var(--theme-link-color);
 

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -27,6 +27,10 @@ We’re continually improving Pelican. The following changes are listed by the d
 - Fix bug of links in Tables not inheriting color
 - Reformatted dates and headers in What’s New to be easier to scan
 
+## 2.0.4 – December 13 2023
+
+- Remove border from sidebar code samples to align with actual site markup
+
 ## 2.0.3: November 30 2023
 
 - Icons in List Group links are vertically centered

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -16,17 +16,14 @@ You can help improve Pelican. Visit the [Feedback Page](/feedback) to learn how 
 
 We’re continually improving Pelican. The following changes are listed by the date we completed each change.
 
-## 2.0.4 December 2023
+## 2.0.3 December 2023
 
 - Add an omitted CSS variable for Pagination
 - Add an omitted CSS variable for Languages Feature Block
 - Add an omitted CSS variable for Checkbox and Radios active color
 - Fix bug of incorrect CSS variable used in disabled Toggle Tokens
 - Fix bug of links in Tables not inheriting color
-
-## 2.0.3 – November 2023
-
-- Icons in List Group links are vertically centered
+- Fix bug of icons in List Group links not being vertically centered
 
 ## 2.0.2 – 28 November 2023
 

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -16,7 +16,7 @@ You can help improve Pelican. Visit the [Feedback Page](/feedback) to learn how 
 
 We’re continually improving Pelican. The following changes are listed by the date we completed each change.
 
-## 2.0.4: December 05 2023
+## 2.0.5: December 14 2023
 
 - Add omitted CSS variables for Checkbox and Radios active color
 - Add omitted CSS variables for Languages Feature Block

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -16,19 +16,22 @@ You can help improve Pelican. Visit the [Feedback Page](/feedback) to learn how 
 
 We’re continually improving Pelican. The following changes are listed by the date we completed each change.
 
-## 2.0.5: December 14 2023
+## 2.0.4: December 15 2023
 
+- Add omitted CSS variables for Alerts’ border radius
 - Add omitted CSS variables for Checkbox and Radios active color
+- Add omitted CSS variables for some Form controls
 - Add omitted CSS variables for Languages Feature Block
+- Add omitted CSS variables for List Group links
 - Add omitted CSS variables for Pagination
+- Add omitted CSS variables for Official Banner focus indicator color
+- Add omitted CSS variables for Table items
 - Add omitted CSS variables for TOC
-- Fix bug of clashing class name in topbar background
+- Fix bug of mispelled variable names in Nav SCSS rules
 - Fix bug of incorrect CSS variable used in disabled Toggle Tokens
+- Fix bug of clashing class name in Topbar background
 - Fix bug of links in Tables not inheriting color
 - Reformatted dates and headers in What’s New to be easier to scan
-
-## 2.0.4 – December 13 2023
-
 - Remove border from sidebar code samples to align with actual site markup
 
 ## 2.0.3: November 30 2023

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -16,7 +16,7 @@ You can help improve Pelican. Visit the [Feedback Page](/feedback) to learn how 
 
 We’re continually improving Pelican. The following changes are listed by the date we completed each change.
 
-## 2.0.3 December 2023
+## 2.0.3 - 05 December 2023
 
 - Add an omitted CSS variable for Pagination
 - Add an omitted CSS variable for Languages Feature Block

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -16,26 +16,31 @@ You can help improve Pelican. Visit the [Feedback Page](/feedback) to learn how 
 
 We’re continually improving Pelican. The following changes are listed by the date we completed each change.
 
-## 2.0.3 - 05 December 2023
+## 2.0.4: December 05 2023
 
-- Add an omitted CSS variable for Pagination
-- Add an omitted CSS variable for Languages Feature Block
-- Add an omitted CSS variable for Checkbox and Radios active color
+- Add omitted CSS variables for Checkbox and Radios active color
+- Add omitted CSS variables for Languages Feature Block
+- Add omitted CSS variables for Pagination
+- Add omitted CSS variables for TOC
 - Fix bug of incorrect CSS variable used in disabled Toggle Tokens
 - Fix bug of links in Tables not inheriting color
-- Fix bug of icons in List Group links not being vertically centered
+- Reformatted dates and headers in What’s New to be easier to scan
 
-## 2.0.2 – 28 November 2023
+## 2.0.3: November 30 2023
+
+- Icons in List Group links are vertically centered
+
+## 2.0.2: November 28 2023
 
 - Links in tables get underlines, and double underlines on hover, by default for accessibility.
 - Sidebar button gets a hover state border change
 - Removes text selection styles and variables
 
-## 2.0.1 - 23 October 2023
+## 2.0.1: October 23 2023
 
 - Added additional theming variables
 
-## 2.0.0 – 16 October 2023
+## 2.0.0: October 16 2023
 
 - **Bootstrap 5.** Bootstrap updated from version 4 to version 5. Pelican 2 is based upon Bootstrap 5.2 but Pelican 1 is based upon Bootstrap 4.6. This major change in Bootstrap version required some things to be refactored in the code to accommodate this. See the [Migration Guide](/migration-guide/) for details about how this affects projects built upon Pelican 1 (Bootstrap 4.6).
 - **CSS Variables.** Easier code theming for dependent projects. Bootstrap 5 introduces the use of CSS variables to enable better theming flexibility. Be sure to tell your developer.

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -16,6 +16,14 @@ You can help improve Pelican. Visit the [Feedback Page](/feedback) to learn how 
 
 We’re continually improving Pelican. The following changes are listed by the date we completed each change.
 
+## 2.0.4 December 2023
+
+- Add an omitted CSS variable for Pagination
+- Add an omitted CSS variable for Languages Feature Block
+- Add an omitted CSS variable for Checkbox and Radios active color
+- Fix bug of incorrect CSS variable used in disabled Toggle Tokens
+- Fix bug of links in Tables not inheriting color
+
 ## 2.0.3 – November 2023
 
 - Icons in List Group links are vertically centered

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -16,6 +16,10 @@ You can help improve Pelican. Visit the [Feedback Page](/feedback) to learn how 
 
 We’re continually improving Pelican. The following changes are listed by the date we completed each change.
 
+## 2.0.3 – November 2023
+
+- Icons in List Group links are vertically centered
+
 ## 2.0.2 – 28 November 2023
 
 - Links in tables get underlines, and double underlines on hover, by default for accessibility.

--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -22,6 +22,7 @@ We’re continually improving Pelican. The following changes are listed by the d
 - Add omitted CSS variables for Languages Feature Block
 - Add omitted CSS variables for Pagination
 - Add omitted CSS variables for TOC
+- Fix bug of clashing class name in topbar background
 - Fix bug of incorrect CSS variable used in disabled Toggle Tokens
 - Fix bug of links in Tables not inheriting color
 - Reformatted dates and headers in What’s New to be easier to scan

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.0.4",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@la-ots/pelican",
-      "version": "2.0.4",
+      "version": "2.0.3",
       "license": "CC0-1.0",
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@la-ots/pelican",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "CC0-1.0",
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@la-ots/pelican",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "CC0-1.0",
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@la-ots/pelican",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "CC0-1.0",
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.0.5",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@la-ots/pelican",
-      "version": "2.0.5",
+      "version": "2.0.4",
       "license": "CC0-1.0",
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Pelican Design System for Louisiana OTS",
   "repository": "git://github.com/la-ots/pelican.git",
   "license": "CC0-1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.0.5",
+  "version": "2.0.4",
   "description": "Pelican Design System for Louisiana OTS",
   "repository": "git://github.com/la-ots/pelican.git",
   "license": "CC0-1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Pelican Design System for Louisiana OTS",
   "repository": "git://github.com/la-ots/pelican.git",
   "license": "CC0-1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Pelican Design System for Louisiana OTS",
   "repository": "git://github.com/la-ots/pelican.git",
   "license": "CC0-1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.0.4",
+  "version": "2.0.3",
   "description": "Pelican Design System for Louisiana OTS",
   "repository": "git://github.com/la-ots/pelican.git",
   "license": "CC0-1.0",

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -68,7 +68,7 @@
   .wrapper {
     @extend .rounded;
     background-color: var(--theme-ui);
-    color: var(--bs-white);
+    color: var(--theme-gray-white);
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
     padding-left: 0.75rem;

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -66,7 +66,7 @@
   }
   .form-check-input:checked[disabled] ~ .form-check-label {
     border-color: transparent !important;
-    background-color: var(--theme-ui-priority) !important;
+    background-color: var(--theme-ui-priority);
   }
 }
 .was-validated .toggle-token .form-check-input:invalid ~ .form-check-label {

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -66,7 +66,7 @@
   }
   .form-check-input:checked[disabled] ~ .form-check-label {
     border-color: transparent !important;
-    background-color: var(--theme-info-500) !important;
+    background-color: var(--theme-ui-priority) !important;
   }
 }
 .was-validated .toggle-token .form-check-input:invalid ~ .form-check-label {

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -72,10 +72,7 @@
 .was-validated .toggle-token .form-check-input:invalid ~ .form-check-label {
   border-color: var(--theme-danger);
 }
-.was-validated
-  .toggle-token
-  .form-check-input:checked:valid
-  ~ .form-check-label {
+.was-validated .toggle-token .form-check-input:checked:valid ~ .form-check-label {
   color: $white;
   background-color: var(--theme-success);
   border-color: var(--theme-success);

--- a/scss/_custom-forms.scss
+++ b/scss/_custom-forms.scss
@@ -32,9 +32,9 @@
       @extend .visually-hidden;
       &:checked {
         + .form-check-label {
-          color: var(--bs-white);
-          background-color: var(--theme-ui-priority);
-          border-color: var(--theme-ui-priority);
+          color: var(--theme-form-check-input-color);
+          background-color: var(--theme-form-check-input-checked-bg-color);
+          border-color: var(--theme-form-check-input-checked-border-color);
           .icon {
             position: absolute;
             top: 8px;

--- a/scss/_default-theme-variables.scss
+++ b/scss/_default-theme-variables.scss
@@ -153,6 +153,8 @@
   /* 4. Set the properties for Bootstrap and Pelican items */
   /* alerts */
 
+  --theme-alert-border-radius: .25rem;
+
   --theme-alert-success-text-color: var(--theme-success-900);
   --theme-alert-success-bg-color: var(--theme-success-100);
   --theme-alert-success-border-color: var(--theme-success-900);
@@ -203,6 +205,7 @@
 
   --theme-badge-chip-warning-bg-color: var(--theme-warning);
   --theme-badge-chip-warning-text-color: var(--bs-black);
+
   --theme-badge-chip-danger-bg-color: var(--theme-danger);
   --theme-badge-chip-danger-text-color: var(--theme-gray-white);
 
@@ -267,12 +270,13 @@
   /* forms */
   /* forms are not yet fully enabled with CSS Variables */
 
-  --theme-form-border-color: var(--theme-border-color);
+  --theme-form-border-color: var(--theme-text-normal);
   --theme-form-disabled-bg-color: var(--theme-ui-light);
   --theme-form-input-color: var(--theme-gray-700);
   --theme-form-input-shadow-color: var(--theme-ui-light);
   --theme-input-btn-focus-color: var(--theme-focus-color);
   --theme-form-active-color: var(--theme-ui-priority);
+  --theme-form-check-input-color: var(--theme-gray-white);
   --theme-form-check-input-checked-bg-color: var(--theme-ui-priority);
   --theme-form-check-input-checked-border-color: var(--theme-ui-priority);
 
@@ -318,6 +322,7 @@
 
   /* List Groups */
 
+  --theme-list-group-link-color: var(--theme-link-color);
   --theme-list-group-bg: var(--theme-card-bg-color);
   --theme-list-group-border-color: var(--theme-card-border-color);
 
@@ -345,6 +350,7 @@
 
   --theme-official-banner-text-color: var(--theme-gray-white);
   --theme-official-banner-bg: var(--theme-gray-black);
+  --theme-official-banner-focus-indicator-color: var(--theme-gray-white);
 
   /* page header, title */
 
@@ -352,6 +358,13 @@
   --theme-page-title-text-color: var(--theme-text-headings-color);
   --theme-page-title-icon-color: var(--theme-page-title-text-color);
   --theme-page-title-border-color: var(--theme-border-color-lighter);
+
+  	/* pagination */
+
+    --theme-pagination-color: var(--theme-link-color);
+    --theme-pagination-hover-color: var(--theme-link-color);
+    --theme-pagination-active-color: var(--theme-link-color);
+	  --theme-pagination-border-color: var(--theme-border-color-lighter);
 
   /* popovers and tooltips */
 
@@ -376,12 +389,12 @@
 
   /* sidebar & topbar */
 
-  --theme-topbar-bg-color: var(--theme-gray-black);
-  --theme-topbar-text-color: var(--theme-gray-white);
+  --theme-topbar-bg-color: var(--bs-black);
+  --theme-topbar-text-color: var(--bs-white);
   --theme-sidebar-brand-bg-color: var(--theme-topbar-bg-color);
   --theme-sidebar-wrapper-bg-color: var(--theme-primary);
   --theme-sidebar-header-border-color: var(--theme-primary-900);
-  --theme-sidebar-link-color: var(--theme-gray-white);
+  --theme-sidebar-link-color: var(--bs-white);
   --theme-sidebar-link-hover-color: var(--theme-gray-white);
   --theme-sidebar-item-bg-color: var(--theme-info);
   --theme-sidebar-submenu-bg-color: var(--theme-primary-900);
@@ -393,8 +406,8 @@
 
   /* tables */
 
-  --theme-table-border-width: 1px;
-  --theme-table-border-width-thick: 3px;
+  --theme-table-border-width: 0.0625rem;
+  --theme-table-border-width-thick: 0.1875rem;
   --theme-table-cell-padding: 0.5rem;
   --theme-table-striped-bg: var(--theme-body-bg);
   --theme-table-border-color: var(--theme-border-color-lighter);
@@ -426,6 +439,7 @@
 
   /* toc */
 
+  --theme-toc-header-color: var(--bs-heading-color);
   --theme-toc-link-color: var(--theme-link-color);
   --theme-toc-link-hover-color: var(--theme-link-color);
 
@@ -433,16 +447,18 @@
   
   /* you will need to provide a font reference if you override the default */
   --theme-font-family: "Public Sans", "Public SansVariable", -apple-system, blinkmacsystemfont, "Segoe UI", "Helvetica Neue", "Arial", "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  --bs-body-font-family: var(--theme-font-family);
   --theme-small-text-color: var(--theme-gray-700);
   --theme-blockquote-bg-color: var(--theme-ui-light);
   --theme-blockquote-border-color: var(--theme-ui);
   --theme-bolded-text-color: var(--themegray--black);
+  --theme-text-selection-text-color: var(--theme-primary-700);
+  --theme-text-selection-bg-color: var(--theme-primary-200);
   --theme-text-decoration-line: underline;
   --theme-text-decoration-style: dashed;
   --theme-text-decoration-color: var(--theme-info-500);
   --theme-text-decoration-thickness: var(--theme-border-width);
   --theme-text-headings-color: var(--theme-primary);
+  --bs-body-font-family: var(--theme-font-family);
   --bs-heading-color: var(--theme-text-headings-color);
 }
 
@@ -555,10 +571,6 @@
   --bs-btn-disabled-color: var(--bs-white);
   --bs-btn-disabled-bg: var(--theme-danger-200);
   --bs-btn-disabled-border-color: var(--theme-danger-200);
-}
-
-.pagination {
-  --bs-pagination-bg: var(--theme-gray-white);
 }
 
 /* 6. Save file! */

--- a/scss/_default-theme-variables.scss
+++ b/scss/_default-theme-variables.scss
@@ -240,9 +240,6 @@
 
   --theme-focus-color: #2491ff;
 
-  /* form validation */
-  --theme-form-validation-error-muted-color: var(--theme-danger-200);
-
   /* feature blocks */
   /* you may need still need to change the classes on buttons */
 
@@ -278,6 +275,9 @@
   --theme-form-active-color: var(--theme-ui-priority);
   --theme-form-check-input-checked-bg-color: var(--theme-ui-priority);
   --theme-form-check-input-checked-border-color: var(--theme-ui-priority);
+
+  /* form validation */
+  --theme-form-validation-error-muted-color: var(--theme-danger-200);
 
   /* footers */
   /* you may need still need to change the classes on buttons */

--- a/scss/_default-theme-variables.scss
+++ b/scss/_default-theme-variables.scss
@@ -257,6 +257,7 @@
 
   --theme-feature-languages-bg-color: var(--theme-accent);
   --theme-feature-languages-text-color: var(--theme-primary);
+  --theme-feature-languages-item-text-color: var(--theme-primary);
   --theme-feature-languages-item-bg-color: var(--theme-gray-white);
 
   --theme-feature-many-icons-text-bg-color: var(--theme-primary);

--- a/scss/_default-theme-variables.scss
+++ b/scss/_default-theme-variables.scss
@@ -276,6 +276,8 @@
   --theme-form-input-shadow-color: var(--theme-ui-light);
   --theme-input-btn-focus-color: var(--theme-focus-color);
   --theme-form-active-color: var(--theme-ui-priority);
+  --theme-form-check-input-checked-bg-color: var(--theme-ui-priority);
+  --theme-form-check-input-checked-border-color: var(--theme-ui-priority);
 
   /* footers */
   /* you may need still need to change the classes on buttons */

--- a/scss/_feature.scss
+++ b/scss/_feature.scss
@@ -134,6 +134,7 @@
     padding-top: 1rem;
     padding-bottom: 1rem;
     margin-top: 1rem;
+    color: var(--theme-feature-languages-item-text-color);
     background-color: var(--theme-feature-languages-item-bg-color);
     p {
       @extend .h4;

--- a/scss/_focus.scss
+++ b/scss/_focus.scss
@@ -63,7 +63,7 @@ a {
 }
 .official-banner .btn.expander {
   &:focus {
-    outline-color: $white !important;
+    outline-color: var(--theme-official-banner-focus-indicator-color) !important;
   }
 }
 

--- a/scss/_form-check.scss
+++ b/scss/_form-check.scss
@@ -1,0 +1,6 @@
+.form-check-input {
+	&:checked {
+		background-color: var(--theme-form-check-input-checked-bg-color);
+		border-color	: var(--theme-form-check-input-checked-border-color);
+	}
+}

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -17,6 +17,6 @@
     font-style: normal;
     font-weight: 900;
     font-variant: normal;
-    margin: 0 1px 0 5px;
+    margin: .25rem 0.0625rem 0 0.3125rem;
   }
 }

--- a/scss/_list-group.scss
+++ b/scss/_list-group.scss
@@ -8,7 +8,7 @@
   background-color: var(--theme-list-group-bg);
 }
 .list-group-item-action {
-  color: var(--theme-link-color);
+  color: var(--theme-list-group-link-color);
   &::after {
     @extend .d-inline-block;
     content: "\f061";

--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -29,12 +29,12 @@
     border: $nav-tabs-border-width solid transparent;
     @include border-top-radius($nav-tabs-border-radius);
     &.disabled {
-      color: var(--theme-ui--light);
+      color: var(--theme-ui-light);
       background-color: transparent;
       border-color: transparent;
     }
     &.active {
-      border-color: var(--theme-nav-tabs-link-active--border-color);
+      border-color: var(--theme-nav-tabs-link-active-border-color);
       border-bottom: none;
     }
     &:hover {

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -1,3 +1,4 @@
 .page-link {
+  color: var(--theme-link-color);
   border: 2px solid var(--theme-form-border-color);
 }

--- a/scss/_pagination.scss
+++ b/scss/_pagination.scss
@@ -1,4 +1,4 @@
 .page-link {
-  color: var(--theme-link-color);
+  color: var(--theme-pagination-color);
   border: 2px solid var(--theme-form-border-color);
 }

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -50,6 +50,9 @@ caption {
   > :not(caption) > * > * {
     border-bottom-width: 0;
   }
+  a:not([class]) {
+    color: var(--theme-link-color);
+  }
 }
 .table-striped {
   > tbody > tr:nth-of-type(#{$table-striped-order}) > * {

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -1,6 +1,6 @@
 caption {
   caption-side: bottom;
-  border-top: 1px dashed var(--theme-border-color);
+  border-top: 1px dashed var(--theme-table-border-color);
 }
 .table {
   width: 100%;

--- a/scss/_toc.scss
+++ b/scss/_toc.scss
@@ -1,3 +1,12 @@
+.page-contents {
+	summary {
+		color: var(--theme-toc-header-color);
+		*, &::marker {
+			color: inherit;
+		}
+	}
+}
+
 .toc {
   margin-top: 0.5rem;
   ul,

--- a/scss/pelican.scss
+++ b/scss/pelican.scss
@@ -70,6 +70,7 @@ $theme-colors: map-merge($theme-colors, $custom-colors);
 @import "feature";
 @import "footer";
 @import "forms";
+@import "form-check";
 @import "custom-forms";
 @import "hero";
 @import "images";

--- a/scss/pelican.scss
+++ b/scss/pelican.scss
@@ -88,6 +88,7 @@ $theme-colors: map-merge($theme-colors, $custom-colors);
 @import "focus";
 @import "bg-texture";
 @import "pagination";
+@import "toc";
 @import "page-templates";
 
 // this next partial sets the CSS Variables


### PR DESCRIPTION
This PR does the following:

- Add an omitted CSS variable for Pagination
- Add an omitted CSS variable for Languages Feature Block
- Add an omitted CSS variable for Checkbox and Radios active color
- Fix bug of errant class name preventing theming in Topbar
- Fix bug of incorrect CSS variable used in disabled Toggle Tokens
- Fix bug of links in Tables not inheriting color
- Reformatted dates and headers in What’s New to be easier to scan