### PR TITLE
Print options update

### DIFF
--- a/scss/_print.scss
+++ b/scss/_print.scss
@@ -1,17 +1,4 @@
 @media print {
-  #ScrollToTop,
-  #sidebar,
-  #footer,
-  #wrapper-topbar,
-  #sidebar-button,
-  .breadcrumb-wrapper,
-  .btns-previous-next,
-  .skip-to-main,
-  .edit-github,
-  .page-toc {
-    display: none !important;
-  }
-
   .page-wrapper,
   .wrapper-main {
     height: unset;
@@ -39,5 +26,29 @@
   .page-content {
     height: auto !important;
     padding: 0 !important;
+  }
+  
+  //absolute areas to hide 
+  .skip-to-main, 
+  .sidebar-wrapper,
+  .wrapper-topbar,
+  #ScrollToTop,
+  .footer,
+  nav,
+  .popover,
+  .page-toc {
+    display: none !important;
+  }
+
+  //optional areas to hide
+  .breadcrumb-wrapper,
+  .btns-previous-next {
+    display: none !important;
+  }
+
+  //custom features that are hidden
+  .edit-github,
+  #sidebar-button {
+    display: none !important;
   }
 }


### PR DESCRIPTION
Currently as exploration is being performed in other projects, this is a combined list of absolutes & options for users of Pelican to modify the visibility of elements in a printout of any page (with Pelican elements):
**Absolutes**
- Skip to Main
- Sidebar
- Topbar
- Nav elements
- Footer elements
- Popover
- Table of Contents

Optional
- Breadcrumbs
- Specific buttons
- Pagination

Other brainstorming ideas to experiment with:
- Having multiple print style files for toggling variations (similar to component file naming)
- Placing all elements onto one index layer, and making that layer invisible when printing
- Creating a global class style that is manually placed on elements to hide them