### PR TITLE
Update Topbar Aria Attributes

### DIFF
--- a/docs/_includes/markup/app-screen.njk
+++ b/docs/_includes/markup/app-screen.njk
@@ -57,7 +57,7 @@
             <span class="d-none d-md-inline">Current Page Title</span>
           </a>
         </p>
-        <button id="sidebar-button" class="btn btn-sm btn-black sidebar-button" aria-haspop="true" aria-controls="sidebar" tabindex="3">
+        <button id="sidebar-button" class="btn btn-sm btn-black sidebar-button" aria-haspopup="true" aria-controls="sidebar" tabindex="3">
           <span class="icon fas fa-fw fa-bars" aria-hidden="true"></span>
         </button>
       </div>

--- a/docs/components/app-screen.md
+++ b/docs/components/app-screen.md
@@ -78,7 +78,7 @@ The Topbar goes inside of the `class="page-content"`. The Topbar contains a hamb
   <button
     id="sidebar-button"
     class="btn btn-sm btn-black sidebar-button"
-    aria-haspop="true"
+    aria-haspopup="true"
     aria-controls="sidebar"
     tabindex="3">
     <span class="icon fas fa-fw fa-bars" aria-hidden="true"></span>


### PR DESCRIPTION
This PR does the following:

- Corrects the "aria-haspop" attribute to "aria-haspopup" on the sidebar-button in the topbar of the App Screen component.

