### PR TITLE
Fix Button Misalignment

### DIFF
--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -16,6 +16,10 @@ You can help improve Pelican. Visit the [Feedback Page](/feedback) to learn how 
 
 We’re continually improving Pelican. The following changes are listed by the date we completed each change.
 
+## 2.0.6: February 21, 2024
+
+- Fixes a `btn btn-link` misalignment bug
+
 ## 2.0.5: January 25, 2024
 
 - Fixes color bugs in the Add Data button

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@la-ots/pelican",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "CC0-1.0",
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Pelican Design System for Louisiana OTS",
   "repository": "git://github.com/la-ots/pelican.git",
   "license": "CC0-1.0",

--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -19,23 +19,19 @@
   border-radius: 0.25rem;
   .btn {
     width: 100%;
-    &:not(:last-of-type) {
-      margin-bottom: 0.5rem;
-    }
-    &.btn-link {
-      margin-right: 0;
-    }
-    @media screen and (min-width: 1024px) {
-      width: unset;
-      &:not(:last-of-type) {
-        margin-right: 0.5rem;
-        margin-bottom: 0;
-      }
-    }
   }
   .col-12 {
-    @media screen and (min-width: 1024px) {
-      display: flex;
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    gap: .5rem;
+  }
+  @media screen and (min-width: 1024px){
+    .btn {
+      width: unset;
+    }
+    .col-12 {
+      flex-direction: row;
       flex-wrap: wrap;
     }
   }


### PR DESCRIPTION
This PR fixes a bug which causes some `<a>` elements with `btn` class to vertically misalign with other elements of the same class.