### PR TITLE
Fix Markup Typos

### DIFF
--- a/docs/_includes/markup/pagination.njk
+++ b/docs/_includes/markup/pagination.njk
@@ -1,8 +1,8 @@
 <div class="row justify-content-center align-items-md-end">
   <div class="col-md-3">
-    <form action="sampleAction" class="">
+    <form action="sampleAction">
       <label class="visually-hidden" for="NumberItemsToShow">Show how many?</label>
-      <select class="custom-select form-select mb-4 mb-lg-0" aria-label="" id="NumberItemsToShow">
+      <select class="custom-select form-select mb-4 mb-lg-0" id="NumberItemsToShow">
         <option selected>Show 10 per page</option>
         <option value="1">Show 25 per page</option>
         <option value="2">Show 50 per page</option>
@@ -11,7 +11,7 @@
     </form>
   </div>
   <div class="col-md-6">
-    <nav class="" aria-label="Page navigation example">
+    <nav aria-label="Page navigation example">
       <ul class="pagination justify-content-center mb-lg-0">
         <li class="page-item">
           <a class="page-link" href="#" aria-label="Previous">
@@ -42,7 +42,6 @@
     </nav>
   </div>
   <div class="col-md-3 text-center text-lg-right text-lg-end">
-    <p class="mb-2">Showing<br class="d-none d-md-block d-lg-none"> <strong>X</strong> of <strong>Y</strong>
-      items.</p>
+    <p class="mb-2">Showing<br class="d-none d-md-block d-lg-none"> <strong>X</strong> of <strong>Y</strong> items.</p>
   </div>
 </div>

--- a/docs/_includes/markup/select.njk
+++ b/docs/_includes/markup/select.njk
@@ -1,6 +1,6 @@
 <div class="form-group">
   <label for="selectChoices">Label for Select</label>
-  <select class="custom-select form-select" aria-label="" id="selectChoices">
+  <select class="custom-select form-select" id="selectChoices">
     <option selected>&mdash; Select a Numeral &mdash;</option>
     <option value="1">1 (One)</option>
     <option value="2">2 (Two)</option>

--- a/docs/_includes/markup/table.njk
+++ b/docs/_includes/markup/table.njk
@@ -5,13 +5,13 @@
       <th scope="col" id="user">
         <a href="#" role="button">
           <span class="icon fas fa-sort me-1" aria-hidden="true"></span>User
-          <span class="visually-hidden">Sort the table by the data of this user column</span>
+          <span class="visually-hidden">Sort the table by user</span>
         </a>
       </th>
       <th scope="col" id="role">
         <a href="#" role="button">
           <span class="icon fas fa-sort me-1" aria-hidden="true"></span>Role
-          <span class="visually-hidden">Sort the table by the data of this role column</span>
+          <span class="visually-hidden">Sort the table by role</span>
         </a>
       </th>
       <th scope="col" id="figma">
@@ -20,7 +20,7 @@
       <th scope="col" id="team">
         <a href="#" role="button">
           <span class="icon fas fa-sort me-1" aria-hidden="true"></span>Team
-          <span class="visually-hidden">Sort the table by the data of this team column</span>
+          <span class="visually-hidden">Sort the table by team</span>
         </a>
       </th>
     </tr>

--- a/docs/_layouts/area-page.njk
+++ b/docs/_layouts/area-page.njk
@@ -9,7 +9,7 @@ layout: default.njk
     {%- for entry in navPages %}
       {%- if entry.url in page.url %}
         {%- for child in entry.children %}
-          <div class="col-12 col-md-6 col-lg-4" role="listitem">
+          <div class="col-12 col-md-6 col-lg-4 col-xl-3" role="listitem">
             <div class="card mb-0 shadow-none h-100">
               <div class="card-body">
                 {%- if child.img %}

--- a/docs/components/list-group.md
+++ b/docs/components/list-group.md
@@ -41,21 +41,21 @@ eleventyNavigation:
 
 ### Link List
 
-<div class="list-group" role="list-group">
-  <a role="list-item" href="#" class="list-group-item list-group-item-action">An item</a>
-  <a role="list-item" href="#" class="list-group-item list-group-item-action">A second item</a>
-  <a role="list-item" href="#" class="list-group-item list-group-item-action">A third item</a>
-  <a role="list-item" href="#" class="list-group-item list-group-item-action">A fourth item</a>
-  <a role="list-item" href="#" class="list-group-item list-group-item-action">And a fifth one</a>
+<div class="list-group">
+  <a href="#" class="list-group-item list-group-item-action">An item</a>
+  <a href="#" class="list-group-item list-group-item-action">A second item</a>
+  <a href="#" class="list-group-item list-group-item-action">A third item</a>
+  <a href="#" class="list-group-item list-group-item-action">A fourth item</a>
+  <a href="#" class="list-group-item list-group-item-action">And a fifth one</a>
 </div>
 
 <!-- prettier-ignore -->
 ```html
-<div class="list-group" role="list-group">
-  <a role="list-item" href="#" class="list-group-item list-group-item-action">An item</a>
-  <a role="list-item" href="#" class="list-group-item list-group-item-action">A second item</a>
-  <a role="list-item" href="#" class="list-group-item list-group-item-action">A third item</a>
-  <a role="list-item" href="#" class="list-group-item list-group-item-action">A fourth item</a>
-  <a role="list-item" href="#" class="list-group-item list-group-item-action">And a fifth one</a>
+<div class="list-group">
+  <a href="#" class="list-group-item list-group-item-action">An item</a>
+  <a href="#" class="list-group-item list-group-item-action">A second item</a>
+  <a href="#" class="list-group-item list-group-item-action">A third item</a>
+  <a href="#" class="list-group-item list-group-item-action">A fourth item</a>
+  <a href="#" class="list-group-item list-group-item-action">And a fifth one</a>
 </div>
 ```


### PR DESCRIPTION
This PR: 

- removes empty `class` attributes on some markup
- removes empty `aria-label` on some markup
- reduces word count of some screen reader available text
- improves the area page by enabling more content to show at larger screen sizes
- removes erroneous `aria` attributes from the list group with links