### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,9 @@
 # Global Owners
 *   @la-ots/product-delivery-admins
 
+# Package Changes
+package*.json @la-ots/product-delivery-admins
+
 # Docs Owners
 /docs/  @la-ots/docs-maintainers
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/CODEOWNERS` file. The change assigns ownership of all `package*.json` files to the `@la-ots/product-delivery-admins` team.