### PR TITLE
CSS fix for bold Table TH Headers

### DIFF
--- a/docs/whats-new/index.md
+++ b/docs/whats-new/index.md
@@ -16,6 +16,10 @@ You can help improve Pelican. Visit the [Feedback Page](/feedback) to learn how 
 
 We’re continually improving Pelican. The following changes are listed by the date we completed each change.
 
+## 2.3.2: July 9, 2025
+
+- Fixed a bug to ensure that buttons or links appear in bold weight as direct children of table column or row headers
+
 ## 2.3.1: February 17, 2025
 
 - Fixed a [Form Section Header](/form-controls/form-section-header/) CSS bug

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@la-ots/pelican",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "CC0-1.0",
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@la-ots/pelican",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Pelican Design System for Louisiana OTS",
   "repository": "git://github.com/la-ots/pelican.git",
   "license": "CC0-1.0",

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -16,6 +16,11 @@ caption {
     border-top-width: var(--theme-table-border-width);
     background-color: var(--theme-gray-white);
   }
+  th {
+    a, button {
+      font-weight: 700;
+    }
+  }
   thead th {
     vertical-align: bottom;
     border-top-width: var(--theme-table-border-width-thick);


### PR DESCRIPTION
This PR:

- Fixes the CSS to ensure that buttons or links are presented in bold font weight when they are direct children of `<th>` elements