### PR TITLE
Replacing role=dialog div with dialog element

### DIFF
--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -39,7 +39,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Deploy to S3
-        run: aws s3 sync ./dist/docs/ s3://pelican.ots.la.gov --acl public-read
+        run: aws s3 sync ./dist/docs/ s3://pelican.ots.la.gov
 
       - name: Invalidate CloudFront Cache
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_PROD_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/docs-sandbox.yml
+++ b/.github/workflows/docs-sandbox.yml
@@ -40,7 +40,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Deploy to S3
-        run: aws s3 sync ./dist/docs/ s3://pelican-test.ots.la.gov --acl public-read
+        run: aws s3 sync ./dist/docs/ s3://pelican-test.ots.la.gov
 
       - name: Invalidate CloudFront Cache
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_TEST_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/docs-vnext.yml
+++ b/.github/workflows/docs-vnext.yml
@@ -40,7 +40,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Deploy to S3
-        run: aws s3 sync ./dist/docs/ s3://pelican-vnext.ots.la.gov --acl public-read
+        run: aws s3 sync ./dist/docs/ s3://pelican-vnext.ots.la.gov
 
       - name: Invalidate CloudFront Cache
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_VNEXT_DISTRIBUTION_ID }} --paths "/*"

--- a/docs/_includes/markup/modal.njk
+++ b/docs/_includes/markup/modal.njk
@@ -1,37 +1,35 @@
-<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#ModalID" data-bs-toggle="modal" data-bs-target="#ModalID">
-  Launch demo modal
-</button>
+<button type="button" class="btn btn-primary" id="openModalBtn"> Launch demo modal </button>
 
 <dialog
   id="ModalID"
-  class="modal"
+  class="simple-modal"
   aria-labelledby="ModalTitle"
   aria-describedby="ModalBody"
 >
-  <div class="modal-dialog modal-dialog-centered" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h1 class="modal-title" id="ModalTitle">
-          <span class="icon fas fa-bell text-primary-10 me-1" aria-hidden="true"></span>Modal Title
-        </h1>
-        <button
-          type="button"
-          class="close btn-close"
-          data-dismiss="modal"
-          data-bs-dismiss="modal"
-          data-dialog-close
-          aria-label="Close"
-        ></button>
-      </div>
-      <div class="modal-body" id="ModalBody">
-        <p><strong>For strong text, use this markup!</strong></p>
-        <p class="mb-0">For regular text, use this markup. But you can still insert <span class="fw-bold">strong text</span> in this. Now, ready for the question?</p>
-      </div>
-      <div class="modal-footer">
-        <form method="dialog" class="modal-footer-form">
-          <button type="button" class="btn btn-outline-ui" id="resetTimer" value="choice" data-dismiss="modal" data-bs-dismiss="modal">Choice</button>
-          <button type="button" class="btn btn-primary" id="logout_url">Main Choice</button>
-        </form>
+  <div class="simple-modal__content">
+    <div class="modal-header">
+      <h1 class="modal-title h5 mb-0" id="ModalTitle">
+        <span class="icon fas fa-bell text-primary-10 me-1" aria-hidden="true"></span>
+        Modal Title
+      </h1>
+      <button
+        type="button"
+        class="close btn-close"
+        id="closeModalBtn"
+        aria-label="Close"
+      ></button>
+    </div>
+    <div class="modal-body" id="ModalBody">
+      <p><strong>For strong text, use this markup!</strong></p>
+      <p class="mb-0">
+        For regular text, use this markup. But you can still insert
+        <span class="fw-bold">strong text</span> in this. Now, ready for the question?
+      </p>
+    </div>
+    <div class="modal-footer">
+      <div class="modal-footer-form">
+        <button type="button" class="btn btn-outline-ui" id="choiceBtn"> Choice </button>
+        <button type="button" class="btn btn-primary" id="logout_url"> Main Choice </button>
       </div>
     </div>
   </div>

--- a/docs/_includes/markup/modal.njk
+++ b/docs/_includes/markup/modal.njk
@@ -1,25 +1,38 @@
-<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#ModalID" data-bs-toggle="modal" data-bs-target="#ModalID">Launch demo modal</button>
+<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#ModalID" data-bs-toggle="modal" data-bs-target="#ModalID">
+  Launch demo modal
+</button>
 
-<!-- this is the actual modal markup -->
-<div class="modal fade" id="ModalID" tabindex="-1" role="dialog" data-backdrop="static" data-bs-backdrop="static" aria-labelledby="ModalTitle" aria-hidden="true" aria-describedby="ModalTitle">
+<dialog
+  id="ModalID"
+  class="modal"
+  aria-labelledby="ModalTitle"
+  aria-describedby="ModalBody"
+>
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <h1 class="modal-title" id="ModalTitle">
           <span class="icon fas fa-bell text-primary-10 me-1" aria-hidden="true"></span>Modal Title
         </h1>
-        <button type="button" class="close btn-close" data-dismiss="modal" data-bs-dismiss="modal" aria-label="Close"></button>
+        <button
+          type="button"
+          class="close btn-close"
+          data-dismiss="modal"
+          data-bs-dismiss="modal"
+          data-dialog-close
+          aria-label="Close"
+        ></button>
       </div>
-      <div class="modal-body">
+      <div class="modal-body" id="ModalBody">
         <p><strong>For strong text, use this markup!</strong></p>
         <p class="mb-0">For regular text, use this markup. But you can still insert <span class="fw-bold">strong text</span> in this. Now, ready for the question?</p>
       </div>
       <div class="modal-footer">
-        <form method="post">
-          <button type="button" class="btn btn-outline-ui" id="resetTimer" data-dismiss="modal" data-bs-dismiss="modal">Choice</button>
+        <form method="dialog" class="modal-footer-form">
+          <button type="button" class="btn btn-outline-ui" id="resetTimer" value="choice" data-dismiss="modal" data-bs-dismiss="modal">Choice</button>
           <button type="button" class="btn btn-primary" id="logout_url">Main Choice</button>
         </form>
       </div>
     </div>
   </div>
-</div>
+</dialog>

--- a/docs/js/default.js
+++ b/docs/js/default.js
@@ -7,14 +7,13 @@ let sidebarDropdownLink = document.querySelectorAll(
 let scrollToTop = document.getElementById("ScrollToTop");
 
 let slideUp = (target, duration = 500) => {
-  // Check if already hidden or animating
   if (!target || window.getComputedStyle(target).display === "none") return;
 
   target.style.transitionProperty = "height, margin, padding";
   target.style.transitionDuration = duration + "ms";
   target.style.boxSizing = "border-box";
   target.style.height = target.offsetHeight + "px";
-  target.offsetHeight; // Force reflow
+  target.offsetHeight;
   target.style.overflow = "hidden";
   target.style.height = 0;
   target.style.paddingTop = 0;
@@ -38,7 +37,6 @@ let slideUp = (target, duration = 500) => {
 };
 
 let slideDown = (target, duration = 500) => {
-  // Check if already visible or animating
   if (!target || window.getComputedStyle(target).display !== "none") return;
 
   target.style.removeProperty("display");
@@ -54,7 +52,7 @@ let slideDown = (target, duration = 500) => {
   target.style.paddingBottom = 0;
   target.style.marginTop = 0;
   target.style.marginBottom = 0;
-  target.offsetHeight; // Force reflow
+  target.offsetHeight;
   target.style.boxSizing = "border-box";
   target.style.transitionProperty = "height, margin, padding";
   target.style.transitionDuration = duration + "ms";
@@ -73,7 +71,6 @@ let slideDown = (target, duration = 500) => {
   }, duration);
 };
 
-// ADD THE DROPDOWN TOGGLE CODE HERE
 sidebarDropdownLink.forEach((dropdownItem) => {
   const toggleDropdown = (event) => {
     event.preventDefault();
@@ -125,7 +122,6 @@ sidebarDropdownLink.forEach((dropdownItem) => {
 });
 
 function menuA11Y() {
-  //insert menu hidding behavior
   if (sidebar.offsetLeft == 0) {
     sidebar.setAttribute("aria-hidden", "false");
     sidebar.removeAttribute("inert");
@@ -138,6 +134,7 @@ function menuA11Y() {
     sidebar.setAttribute("aria-expanded", "false");
   }
 }
+
 if (sidebar) {
   sidebar.ontransitionend = menuA11Y;
   menuA11Y();
@@ -173,7 +170,6 @@ function scrollFunction() {
   }
 }
 
-// When the user clicks on the button, scroll to the top of the document
 function topFunction() {
   let pageContent = document.getElementsByClassName("page-content");
   if (pageContent && pageContent.length > 0) {
@@ -198,96 +194,72 @@ tooltipTriggerList.map(function (tooltipTriggerEl) {
   return new bootstrap.Tooltip(tooltipTriggerEl);
 });
 
-document.querySelectorAll('[data-toggle="modal"], [data-bs-toggle="modal"]').forEach((button) => {
-  button.addEventListener("click", (event) => {
-    event.preventDefault();
-
-    const targetSelector =
-      button.getAttribute("data-bs-target") ||
-      button.getAttribute("data-target");
-
-    if (!targetSelector) return;
-
-    const dialog = document.querySelector(targetSelector);
-    if (!(dialog instanceof HTMLDialogElement)) return;
-
-    dialog._invoker = button;
-    dialog.showModal();
-
-    setTimeout(() => {
-      const focusables = getFocusableElements(dialog);
-      if (focusables.length) focusables[0].focus();
-    }, 0);
-  });
-});
-
-document.querySelectorAll('[data-dismiss="modal"], [data-bs-dismiss="modal"], [data-dialog-close]').forEach((button) => {
-  button.addEventListener("click", () => {
-    const dialog = button.closest("dialog");
-    if (dialog instanceof HTMLDialogElement) {
-      dialog.close();
-    }
-  });
-});
-
-document.querySelectorAll("dialog.modal").forEach((dialog) => {
-  dialog.addEventListener("close", () => {
-    if (dialog._invoker && typeof dialog._invoker.focus === "function") {
-      dialog._invoker.focus();
-    }
-  });
-
-  dialog.addEventListener("click", (event) => {
-    const modalDialog = dialog.querySelector(".modal-dialog");
-    if (!modalDialog) return;
-
-    const rect = modalDialog.getBoundingClientRect();
-    const clickedInside =
-      event.clientX >= rect.left &&
-      event.clientX <= rect.right &&
-      event.clientY >= rect.top &&
-      event.clientY <= rect.bottom;
-
-    if (!clickedInside) {
-      dialog.close();
-    }
-  });
-
-  dialog.addEventListener("keydown", (event) => {
-    const focusables = getFocusableElements(dialog);
-    if (!focusables.length) return;
-
-    const currentIndex = focusables.indexOf(document.activeElement);
-
-    if (["ArrowRight", "ArrowDown"].includes(event.key)) {
-      event.preventDefault();
-      const nextIndex = (currentIndex + 1) % focusables.length;
-      focusables[nextIndex].focus();
-    }
-
-    if (["ArrowLeft", "ArrowUp"].includes(event.key)) {
-      event.preventDefault();
-      const prevIndex =
-        (currentIndex - 1 + focusables.length) % focusables.length;
-      focusables[prevIndex].focus();
-    }
-
-    if (event.key === "Tab") {
-      if (event.shiftKey && currentIndex === 0) {
-        event.preventDefault();
-        focusables[focusables.length - 1].focus();
-      } else if (!event.shiftKey && currentIndex === focusables.length - 1) {
-        event.preventDefault();
-        focusables[0].focus();
-      }
-    }
-  });
-});
+/* SIMPLE MODAL */
+const modal = document.getElementById("ModalID");
+const openModalBtn = document.getElementById("openModalBtn");
+const closeModalBtn = document.getElementById("closeModalBtn");
+const choiceBtn = document.getElementById("choiceBtn");
 
 function getFocusableElements(container) {
   return Array.from(
     container.querySelectorAll(
-      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
-    )
-  ).filter((el) => el.offsetParent !== null);
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((el) => !el.hasAttribute("hidden"));
+}
+
+function openModal() {
+  if (!(modal instanceof HTMLDialogElement)) return;
+  modal.showModal();
+
+  const focusables = getFocusableElements(modal);
+  if (focusables.length) {
+    focusables[0].focus();
+  }
+}
+
+function closeModal() {
+  if (!(modal instanceof HTMLDialogElement)) return;
+  if (!modal.open) return;
+
+  modal.close();
+  if (openModalBtn) {
+    openModalBtn.focus();
+  }
+}
+
+if (openModalBtn && modal instanceof HTMLDialogElement) {
+  openModalBtn.addEventListener("click", openModal);
+
+  modal.addEventListener("click", (event) => {
+    if (event.target === modal) {
+      event.preventDefault();
+    }
+  });
+
+  modal.addEventListener("keydown", (event) => {
+    if (event.key !== "Tab") return;
+
+    const focusables = getFocusableElements(modal);
+    if (!focusables.length) return;
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  });
+}
+
+if (closeModalBtn) {
+  closeModalBtn.addEventListener("click", closeModal);
+}
+
+if (choiceBtn) {
+  choiceBtn.addEventListener("click", closeModal);
 }

--- a/docs/js/default.js
+++ b/docs/js/default.js
@@ -197,3 +197,97 @@ var tooltipTriggerList = [].slice.call(
 tooltipTriggerList.map(function (tooltipTriggerEl) {
   return new bootstrap.Tooltip(tooltipTriggerEl);
 });
+
+document.querySelectorAll('[data-toggle="modal"], [data-bs-toggle="modal"]').forEach((button) => {
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+
+    const targetSelector =
+      button.getAttribute("data-bs-target") ||
+      button.getAttribute("data-target");
+
+    if (!targetSelector) return;
+
+    const dialog = document.querySelector(targetSelector);
+    if (!(dialog instanceof HTMLDialogElement)) return;
+
+    dialog._invoker = button;
+    dialog.showModal();
+
+    setTimeout(() => {
+      const focusables = getFocusableElements(dialog);
+      if (focusables.length) focusables[0].focus();
+    }, 0);
+  });
+});
+
+document.querySelectorAll('[data-dismiss="modal"], [data-bs-dismiss="modal"], [data-dialog-close]').forEach((button) => {
+  button.addEventListener("click", () => {
+    const dialog = button.closest("dialog");
+    if (dialog instanceof HTMLDialogElement) {
+      dialog.close();
+    }
+  });
+});
+
+document.querySelectorAll("dialog.modal").forEach((dialog) => {
+  dialog.addEventListener("close", () => {
+    if (dialog._invoker && typeof dialog._invoker.focus === "function") {
+      dialog._invoker.focus();
+    }
+  });
+
+  dialog.addEventListener("click", (event) => {
+    const modalDialog = dialog.querySelector(".modal-dialog");
+    if (!modalDialog) return;
+
+    const rect = modalDialog.getBoundingClientRect();
+    const clickedInside =
+      event.clientX >= rect.left &&
+      event.clientX <= rect.right &&
+      event.clientY >= rect.top &&
+      event.clientY <= rect.bottom;
+
+    if (!clickedInside) {
+      dialog.close();
+    }
+  });
+
+  dialog.addEventListener("keydown", (event) => {
+    const focusables = getFocusableElements(dialog);
+    if (!focusables.length) return;
+
+    const currentIndex = focusables.indexOf(document.activeElement);
+
+    if (["ArrowRight", "ArrowDown"].includes(event.key)) {
+      event.preventDefault();
+      const nextIndex = (currentIndex + 1) % focusables.length;
+      focusables[nextIndex].focus();
+    }
+
+    if (["ArrowLeft", "ArrowUp"].includes(event.key)) {
+      event.preventDefault();
+      const prevIndex =
+        (currentIndex - 1 + focusables.length) % focusables.length;
+      focusables[prevIndex].focus();
+    }
+
+    if (event.key === "Tab") {
+      if (event.shiftKey && currentIndex === 0) {
+        event.preventDefault();
+        focusables[focusables.length - 1].focus();
+      } else if (!event.shiftKey && currentIndex === focusables.length - 1) {
+        event.preventDefault();
+        focusables[0].focus();
+      }
+    }
+  });
+});
+
+function getFocusableElements(container) {
+  return Array.from(
+    container.querySelectorAll(
+      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+    )
+  ).filter((el) => el.offsetParent !== null);
+}

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -1,12 +1,88 @@
-.modal-content {
+/* Make native dialog behave like the old Bootstrap modal wrapper */
+dialog.modal {
+  background: transparent;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  border: none !important;
+  outline: none !important;
+  box-shadow: none !important;
+  background: transparent !important;
+  padding: 0;
+}
+dialog.modal:focus {
+  outline: none !important;
+}
+dialog.modal[open] {
+  display: block;
+}
+/* Center the modal exactly like Bootstrap */
+dialog.modal .modal-dialog {
+  width: auto;
+  max-width: 500px;
+  pointer-events: none;
+}
+
+dialog.modal .modal-dialog-centered {
+  min-height: calc(100% - 3.5rem);
+  display: flex;
+  align-items: center;
+}
+dialog.modal .modal-content {
   background-color: var(--theme-modal-dialog-bg-color);
   border: $card-border-width solid var(--theme-modal-dialog-border-color);
+  border-radius: $border-radius;
   .close {
     @extend .position-relative;
     opacity: 1;
   }
 }
-.modal-title {
+dialog.modal .modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}   
+dialog.modal .modal-title {
   @extend .h5;
-  color: var(--theme-modal-dialog-title-color);
+  color: var(--theme-modal-dialog-title-color);          
+}
+dialog.modal .btn-close,
+dialog.modal .close {
+  flex-shrink: 0;
+}
+dialog.modal .modal-body {
+  position: relative;
+  flex: 1 1 auto;
+}
+dialog.modal .modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+dialog.modal .modal-footer-form {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  width: 100%;
+  margin: 0;
+}
+
+dialog.modal .modal-footer-form .btn {
+  margin: 0;
+}
+
+/* Remove odd native spacing in some browsers */
+dialog.modal form[method="dialog"] {
+  padding: 0;
+}
+/* Mobile behavior similar to Bootstrap */
+@media (max-width: 575.98px) {
+  dialog.modal .modal-dialog {
+    max-width: none;
+    margin: 0.5rem;
+  }
+  dialog.modal .modal-dialog-centered {
+    min-height: calc(100% - 1rem);
+  }
 }

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -1,4 +1,3 @@
-/* Make native dialog behave like the old Bootstrap modal wrapper */
 dialog.modal {
   background: transparent;
   width: 100%;
@@ -16,13 +15,11 @@ dialog.modal:focus {
 dialog.modal[open] {
   display: block;
 }
-/* Center the modal exactly like Bootstrap */
 dialog.modal .modal-dialog {
   width: auto;
   max-width: 500px;
   pointer-events: none;
 }
-
 dialog.modal .modal-dialog-centered {
   min-height: calc(100% - 3.5rem);
   display: flex;
@@ -67,16 +64,12 @@ dialog.modal .modal-footer-form {
   width: 100%;
   margin: 0;
 }
-
 dialog.modal .modal-footer-form .btn {
   margin: 0;
 }
-
-/* Remove odd native spacing in some browsers */
 dialog.modal form[method="dialog"] {
   padding: 0;
 }
-/* Mobile behavior similar to Bootstrap */
 @media (max-width: 575.98px) {
   dialog.modal .modal-dialog {
     max-width: none;

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -1,81 +1,83 @@
-dialog.modal {
+dialog.simple-modal {
+  border: none;
+  padding: 0;
   background: transparent;
   width: 100%;
-  height: 100%;
-  overflow: visible;
-  border: none !important;
-  outline: none !important;
-  box-shadow: none !important;
-  background: transparent !important;
-  padding: 0;
-}
-dialog.modal:focus {
-  outline: none !important;
-}
-dialog.modal[open] {
-  display: block;
-}
-dialog.modal .modal-dialog {
-  width: auto;
   max-width: 500px;
-  pointer-events: none;
+  overflow: visible;
 }
-dialog.modal .modal-dialog-centered {
-  min-height: calc(100% - 3.5rem);
-  display: flex;
-  align-items: center;
+
+dialog.simple-modal::backdrop {
+  background: rgba(0, 0, 0, 0.5);
 }
-dialog.modal .modal-content {
+
+dialog.simple-modal:focus {
+  outline: none;
+}
+
+.simple-modal__content {
   background-color: var(--theme-modal-dialog-bg-color);
   border: $card-border-width solid var(--theme-modal-dialog-border-color);
   border-radius: $border-radius;
-  .close {
-    @extend .position-relative;
-    opacity: 1;
-  }
+  overflow: hidden;
+  box-shadow: 0 0.5rem 1rem rgba(0,0,0,.15);
 }
-dialog.modal .modal-header {
+
+
+/* HEADER */
+.simple-modal .modal-header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-}   
-dialog.modal .modal-title {
+  padding: 1rem 1rem;
+  border-bottom: 1px solid #dee2e6;
+}
+
+
+/* TITLE */
+.simple-modal .modal-title {
   @extend .h5;
-  color: var(--theme-modal-dialog-title-color);          
+  color: var(--theme-modal-dialog-title-color);
+  margin: 0;
 }
-dialog.modal .btn-close,
-dialog.modal .close {
-  flex-shrink: 0;
-}
-dialog.modal .modal-body {
+
+
+/* BODY */
+.simple-modal .modal-body {
+  padding: 1rem;
   position: relative;
   flex: 1 1 auto;
 }
-dialog.modal .modal-footer {
+
+
+/* FOOTER */
+.simple-modal .modal-footer {
   display: flex;
-  align-items: center;
   justify-content: flex-end;
+  padding: 1rem;
+  border-top: 1px solid #dee2e6;
 }
-dialog.modal .modal-footer-form {
+
+.simple-modal .modal-footer-form {
   display: flex;
-  align-items: center;
-  justify-content: flex-end;
   gap: 0.75rem;
   width: 100%;
-  margin: 0;
+  justify-content: flex-end;
 }
-dialog.modal .modal-footer-form .btn {
-  margin: 0;
+
+
+/* CLOSE BUTTON */
+.simple-modal .btn-close,
+.simple-modal .close {
+  flex-shrink: 0;
+  opacity: 1;
 }
-dialog.modal form[method="dialog"] {
-  padding: 0;
-}
+
+
+/* MOBILE */
 @media (max-width: 575.98px) {
-  dialog.modal .modal-dialog {
+  dialog.simple-modal {
+    width: calc(100% - 1rem);
     max-width: none;
-    margin: 0.5rem;
-  }
-  dialog.modal .modal-dialog-centered {
-    min-height: calc(100% - 1rem);
   }
 }


### PR DESCRIPTION
Replaced `<div role="dialog">` with the native `<dialog>` element.

- Using dialog because - built-in accessibility (focus, modal behavior, semantics)
- Aligns with WCAG best practices
- Added proper tab and keyboard functionality in JS
- Removed acl public-read instances